### PR TITLE
Removing recursive pipeline

### DIFF
--- a/jupyter/annotation/english/text-similarity/Spark-NLP_Spark-ML_Text_Similarity.ipynb
+++ b/jupyter/annotation/english/text-similarity/Spark-NLP_Spark-ML_Text_Similarity.ipynb
@@ -221,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipeline = RecursivePipeline() \\\n",
+    "pipeline = Pipeline() \\\n",
     "      .setStages([documentAssembler,\n",
     "        sentence,\n",
     "        tokenizer,\n",

--- a/jupyter/training/english/crf-ner/ner_dl_crf.ipynb
+++ b/jupyter/training/english/crf-ner/ner_dl_crf.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "This challenging annotator will require the user to provide either a labeled dataset during fit() stage, or use external CoNLL 2003 resources to train. It may optionally use an external word embeddings set and a list of additional entities.\n",
     "\n",
-    "The CRF Annotator will also require Part-of-speech tags so we add those in the same Pipeline. Also, we could use our special RecursivePipeline, which will tell SparkNLP's NER CRF approach to use the same pipeline for tagging external resources.\n",
+    "The CRF Annotator will also require Part-of-speech tags so we add those in the same Pipeline.\n",
     "\n"
    ]
   },

--- a/scala/annotation/NerPerfTest.scala
+++ b/scala/annotation/NerPerfTest.scala
@@ -4,6 +4,7 @@ import com.johnsnowlabs.nlp.base._
 import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsFormat
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.Pipeline
 
 object NerCrfTraining extends App {
 
@@ -38,7 +39,7 @@ object NerCrfTraining extends App {
   val finisher = new Finisher().
     setInputCols("ner")
 
-  val recursivePipeline = new RecursivePipeline().
+  val pipeline = new Pipeline().
     setStages(Array(
       documentAssembler,
       tokenizer,
@@ -47,7 +48,7 @@ object NerCrfTraining extends App {
       finisher
     ))
 
-  val nermodel = recursivePipeline.fit(Seq.empty[String].toDF("text"))
+  val nermodel = pipeline.fit(Seq.empty[String].toDF("text"))
   val nerlpmodel = new LightPipeline(nermodel)
 
   val res = Benchmark.time("Light annotate NerCRF") {
@@ -89,7 +90,7 @@ object NerDLTraining extends App {
   val finisher = new Finisher().
     setInputCols("ner")
 
-  val recursivePipeline = new RecursivePipeline().
+  val pipeline = new Pipeline().
     setStages(Array(
       documentAssembler,
       tokenizer,
@@ -97,7 +98,7 @@ object NerDLTraining extends App {
       finisher
     ))
 
-  val nermodel = recursivePipeline.fit(Seq.empty[String].toDF("text"))
+  val nermodel = pipeline.fit(Seq.empty[String].toDF("text"))
   val nerlpmodel = new LightPipeline(nermodel)
 
   val res = Benchmark.time("Light annotate NerDL") {
@@ -140,7 +141,7 @@ object NerDLPretrained extends App {
   val finisher = new Finisher().
     setInputCols("token", "sentence", "nerconverter", "ner")
 
-  val recursivePipeline = new RecursivePipeline().
+  val pipeline = new Pipeline().
     setStages(Array(
       documentAssembler,
       sentenceDetector,
@@ -150,7 +151,7 @@ object NerDLPretrained extends App {
       finisher
     ))
 
-  val nermodel = recursivePipeline.fit(Seq.empty[String].toDF("text"))
+  val nermodel = pipeline.fit(Seq.empty[String].toDF("text"))
   val nerlpmodel = new LightPipeline(nermodel)
 
   val res1 = Benchmark.time("Light annotate NerDL") {
@@ -205,7 +206,7 @@ object NerCrfPretrained extends App {
   val finisher = new Finisher().
     setInputCols("token", "sentence", "nerconverter", "ner")
 
-  val recursivePipeline = new RecursivePipeline().
+  val pipeline = new Pipeline().
     setStages(Array(
       documentAssembler,
       sentenceDetector,
@@ -216,7 +217,7 @@ object NerCrfPretrained extends App {
       finisher
     ))
 
-  val nermodel = recursivePipeline.fit(Seq.empty[String].toDF("text"))
+  val nermodel = pipeline.fit(Seq.empty[String].toDF("text"))
   val nerlpmodel = new LightPipeline(nermodel)
 
   val res1 = Benchmark.time("Light annotate NerCrf") {

--- a/scala/annotation/SparkNLP_Similarity_Test.scala
+++ b/scala/annotation/SparkNLP_Similarity_Test.scala
@@ -4,7 +4,8 @@
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.embeddings.{BertEmbeddings, SentenceEmbeddings, WordEmbeddingsModel}
-import com.johnsnowlabs.nlp.{DocumentAssembler, EmbeddingsFinisher, RecursivePipeline}
+import com.johnsnowlabs.nlp.{DocumentAssembler, EmbeddingsFinisher}
+import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.feature.{BucketedRandomProjectionLSH, BucketedRandomProjectionLSHModel, LSH, Normalizer, SQLTransformer}
 import org.apache.spark.ml.feature.{MinHashLSH, MinHashLSHModel}
@@ -90,7 +91,7 @@ def buildPipeline(): Unit = {
     
     val similartyChecker = new BucketedRandomProjectionLSH().setInputCol("features").setOutputCol("hashes").setBucketLength(6.0).setNumHashTables(6)
   
-    val pipeline = new RecursivePipeline()
+    val pipeline = new Pipeline()
       .setStages(Array(documentAssembler,
         sentence,
         tokenizer,

--- a/scala/annotation/SpellCheckersPerfTest.scala
+++ b/scala/annotation/SpellCheckersPerfTest.scala
@@ -4,6 +4,7 @@ import com.johnsnowlabs.nlp.base._
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.util.Benchmark
 import org.apache.spark.sql.functions.rand
+import org.apache.spark.ml.Pipeline
 
 class NorvigSweetingTest extends App {
 
@@ -27,7 +28,7 @@ class NorvigSweetingTest extends App {
   val finisher = new Finisher().
     setInputCols("spell")
 
-  val recursivePipeline = new RecursivePipeline().
+  val pipeline = new Pipeline().
     setStages(Array(
       documentAssembler,
       tokenizer,
@@ -35,7 +36,7 @@ class NorvigSweetingTest extends App {
       finisher
     ))
 
-  val spellmodel = recursivePipeline.fit(Seq.empty[String].toDF("text"))
+  val spellmodel = pipeline.fit(Seq.empty[String].toDF("text"))
   val spellplight = new LightPipeline(spellmodel)
 
   val n = 50
@@ -72,7 +73,7 @@ class SymmetricDeleteTest extends App {
   val finisher = new Finisher().
     setInputCols("spell")
 
-  val recursivePipeline = new RecursivePipeline().
+  val pipeline = new Pipeline().
     setStages(Array(
       documentAssembler,
       tokenizer,
@@ -80,7 +81,7 @@ class SymmetricDeleteTest extends App {
       finisher
     ))
 
-  val spellmodel = recursivePipeline.fit(Seq.empty[String].toDF("text"))
+  val spellmodel = pipeline.fit(Seq.empty[String].toDF("text"))
   val spellplight = new LightPipeline(spellmodel)
 
   val n = 50000

--- a/scala/healthcare/NerChunkerFiltererExample.scala
+++ b/scala/healthcare/NerChunkerFiltererExample.scala
@@ -1,10 +1,11 @@
 import AssertionDLApproachExample.spark
-import com.johnsnowlabs.nlp.{DocumentAssembler, RecursivePipeline}
+import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotator.{NerDLModel, SentenceDetector, WordEmbeddingsModel}
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.ner.NerChunker
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.ml.Pipeline
 
 object NerChunkerFiltererExample extends App {
 
@@ -54,7 +55,7 @@ object NerChunkerFiltererExample extends App {
     .setRegexParsers(Array("<PER>.*<LOC>"))
 
 
-  val recursivePipeline = new RecursivePipeline()
+  val pipeline = new Pipeline()
     .setStages(Array(
       documentAssembler,
       sentenceDetector,
@@ -64,7 +65,7 @@ object NerChunkerFiltererExample extends App {
       chunker
     ))
 
-  val nermodel = recursivePipeline.fit(data).transform(data)
+  val nermodel = pipeline.fit(data).transform(data)
 
 
   val dataframe = nermodel.select("ner_chunk.result")

--- a/scala/healthcare/NerConverterInternalExample.scala
+++ b/scala/healthcare/NerConverterInternalExample.scala
@@ -1,10 +1,11 @@
 import AssertionDLApproachExample.spark
-import com.johnsnowlabs.nlp.{DocumentAssembler, RecursivePipeline}
+import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotator.{NerDLModel, SentenceDetector, WordEmbeddingsModel}
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.ner.NerConverterInternal
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.ml.Pipeline
 
 object NerConverterInternalExample extends App {
 
@@ -53,7 +54,7 @@ object NerConverterInternalExample extends App {
     .setPreservePosition(false)
     .setThreshold(9900e-4f)
 
-  val recursivePipeline = new RecursivePipeline()
+  val pipeline = new Pipeline()
     .setStages(Array(
       documentAssembler,
       sentenceDetector,
@@ -63,7 +64,7 @@ object NerConverterInternalExample extends App {
       converter
     ))
 
-  val nermodel = recursivePipeline.fit(data).transform(data)
+  val nermodel = pipeline.fit(data).transform(data)
 
   nermodel.select("token.result").show(1, false)
   nermodel.select("embeddings.result").show(1, false)

--- a/scala/training/NerDL/win/customNerDlPipeline/CustomForNerDLPipeline.java
+++ b/scala/training/NerDL/win/customNerDlPipeline/CustomForNerDLPipeline.java
@@ -71,7 +71,7 @@ object CustomForNerDLPipeline{
         val finisher=new Finisher().setInputCols("ner","ner_converter").setIncludeMetadata(true).setOutputAsArray(false)
         .setCleanAnnotations(false).setAnnotationSplitSymbol("@").setValueSplitSymbol("#")
 
-        val pipeline=new RecursivePipeline()
+        val pipeline=new Pipeline()
         .setStages(Array(document,token,word_embeddings,ner,nerConverter,finisher))
 
         val testingForTop10Carriers=Seq(


### PR DESCRIPTION
Replaces `RecursivePipeline()` with `Pipeline()` in scala, java scripts and Jupyter notebooks. Imports modified / added where needed.