### PR TITLE
added conll creation script with regex tokenizer

### DIFF
--- a/tutorials/Annotation_Lab/AL_API_import_export_pre_annotate.ipynb
+++ b/tutorials/Annotation_Lab/AL_API_import_export_pre_annotate.ipynb
@@ -1,1917 +1,2060 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![JohnSnowLabs](https://nlp.johnsnowlabs.com/assets/images/logo.png)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Annotation_Lab/AL_API_import_export_pre_annotate.ipynb)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9EQwCxr7JGh8"
-   },
-   "source": [
-    "# Connect to Annotation Lab via API.\n",
-    "## This tutorial provides instrudctions and code for the following operations:\n",
-    "- Uploading Pre-annotations to Alab\n",
-    "- Importing a project from Alab, and converting to get conll, Assertion files.\n",
-    "- Uploading tasks without pre-annotations."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 73,
-     "resources": {
-      "http://localhost:8080/nbextensions/google.colab/files.js": {
-       "data": "Ly8gQ29weXJpZ2h0IDIwMTcgR29vZ2xlIExMQwovLwovLyBMaWNlbnNlZCB1bmRlciB0aGUgQXBhY2hlIExpY2Vuc2UsIFZlcnNpb24gMi4wICh0aGUgIkxpY2Vuc2UiKTsKLy8geW91IG1heSBub3QgdXNlIHRoaXMgZmlsZSBleGNlcHQgaW4gY29tcGxpYW5jZSB3aXRoIHRoZSBMaWNlbnNlLgovLyBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKLy8KLy8gICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvTElDRU5TRS0yLjAKLy8KLy8gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQovLyBkaXN0cmlidXRlZCB1bmRlciB0aGUgTGljZW5zZSBpcyBkaXN0cmlidXRlZCBvbiBhbiAiQVMgSVMiIEJBU0lTLAovLyBXSVRIT1VUIFdBUlJBTlRJRVMgT1IgQ09ORElUSU9OUyBPRiBBTlkgS0lORCwgZWl0aGVyIGV4cHJlc3Mgb3IgaW1wbGllZC4KLy8gU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAovLyBsaW1pdGF0aW9ucyB1bmRlciB0aGUgTGljZW5zZS4KCi8qKgogKiBAZmlsZW92ZXJ2aWV3IEhlbHBlcnMgZm9yIGdvb2dsZS5jb2xhYiBQeXRob24gbW9kdWxlLgogKi8KKGZ1bmN0aW9uKHNjb3BlKSB7CmZ1bmN0aW9uIHNwYW4odGV4dCwgc3R5bGVBdHRyaWJ1dGVzID0ge30pIHsKICBjb25zdCBlbGVtZW50ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc3BhbicpOwogIGVsZW1lbnQudGV4dENvbnRlbnQgPSB0ZXh0OwogIGZvciAoY29uc3Qga2V5IG9mIE9iamVjdC5rZXlzKHN0eWxlQXR0cmlidXRlcykpIHsKICAgIGVsZW1lbnQuc3R5bGVba2V5XSA9IHN0eWxlQXR0cmlidXRlc1trZXldOwogIH0KICByZXR1cm4gZWxlbWVudDsKfQoKLy8gTWF4IG51bWJlciBvZiBieXRlcyB3aGljaCB3aWxsIGJlIHVwbG9hZGVkIGF0IGEgdGltZS4KY29uc3QgTUFYX1BBWUxPQURfU0laRSA9IDEwMCAqIDEwMjQ7CgpmdW5jdGlvbiBfdXBsb2FkRmlsZXMoaW5wdXRJZCwgb3V0cHV0SWQpIHsKICBjb25zdCBzdGVwcyA9IHVwbG9hZEZpbGVzU3RlcChpbnB1dElkLCBvdXRwdXRJZCk7CiAgY29uc3Qgb3V0cHV0RWxlbWVudCA9IGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKG91dHB1dElkKTsKICAvLyBDYWNoZSBzdGVwcyBvbiB0aGUgb3V0cHV0RWxlbWVudCB0byBtYWtlIGl0IGF2YWlsYWJsZSBmb3IgdGhlIG5leHQgY2FsbAogIC8vIHRvIHVwbG9hZEZpbGVzQ29udGludWUgZnJvbSBQeXRob24uCiAgb3V0cHV0RWxlbWVudC5zdGVwcyA9IHN0ZXBzOwoKICByZXR1cm4gX3VwbG9hZEZpbGVzQ29udGludWUob3V0cHV0SWQpOwp9CgovLyBUaGlzIGlzIHJvdWdobHkgYW4gYXN5bmMgZ2VuZXJhdG9yIChub3Qgc3VwcG9ydGVkIGluIHRoZSBicm93c2VyIHlldCksCi8vIHdoZXJlIHRoZXJlIGFyZSBtdWx0aXBsZSBhc3luY2hyb25vdXMgc3RlcHMgYW5kIHRoZSBQeXRob24gc2lkZSBpcyBnb2luZwovLyB0byBwb2xsIGZvciBjb21wbGV0aW9uIG9mIGVhY2ggc3RlcC4KLy8gVGhpcyB1c2VzIGEgUHJvbWlzZSB0byBibG9jayB0aGUgcHl0aG9uIHNpZGUgb24gY29tcGxldGlvbiBvZiBlYWNoIHN0ZXAsCi8vIHRoZW4gcGFzc2VzIHRoZSByZXN1bHQgb2YgdGhlIHByZXZpb3VzIHN0ZXAgYXMgdGhlIGlucHV0IHRvIHRoZSBuZXh0IHN0ZXAuCmZ1bmN0aW9uIF91cGxvYWRGaWxlc0NvbnRpbnVlKG91dHB1dElkKSB7CiAgY29uc3Qgb3V0cHV0RWxlbWVudCA9IGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKG91dHB1dElkKTsKICBjb25zdCBzdGVwcyA9IG91dHB1dEVsZW1lbnQuc3RlcHM7CgogIGNvbnN0IG5leHQgPSBzdGVwcy5uZXh0KG91dHB1dEVsZW1lbnQubGFzdFByb21pc2VWYWx1ZSk7CiAgcmV0dXJuIFByb21pc2UucmVzb2x2ZShuZXh0LnZhbHVlLnByb21pc2UpLnRoZW4oKHZhbHVlKSA9PiB7CiAgICAvLyBDYWNoZSB0aGUgbGFzdCBwcm9taXNlIHZhbHVlIHRvIG1ha2UgaXQgYXZhaWxhYmxlIHRvIHRoZSBuZXh0CiAgICAvLyBzdGVwIG9mIHRoZSBnZW5lcmF0b3IuCiAgICBvdXRwdXRFbGVtZW50Lmxhc3RQcm9taXNlVmFsdWUgPSB2YWx1ZTsKICAgIHJldHVybiBuZXh0LnZhbHVlLnJlc3BvbnNlOwogIH0pOwp9CgovKioKICogR2VuZXJhdG9yIGZ1bmN0aW9uIHdoaWNoIGlzIGNhbGxlZCBiZXR3ZWVuIGVhY2ggYXN5bmMgc3RlcCBvZiB0aGUgdXBsb2FkCiAqIHByb2Nlc3MuCiAqIEBwYXJhbSB7c3RyaW5nfSBpbnB1dElkIEVsZW1lbnQgSUQgb2YgdGhlIGlucHV0IGZpbGUgcGlja2VyIGVsZW1lbnQuCiAqIEBwYXJhbSB7c3RyaW5nfSBvdXRwdXRJZCBFbGVtZW50IElEIG9mIHRoZSBvdXRwdXQgZGlzcGxheS4KICogQHJldHVybiB7IUl0ZXJhYmxlPCFPYmplY3Q+fSBJdGVyYWJsZSBvZiBuZXh0IHN0ZXBzLgogKi8KZnVuY3Rpb24qIHVwbG9hZEZpbGVzU3RlcChpbnB1dElkLCBvdXRwdXRJZCkgewogIGNvbnN0IGlucHV0RWxlbWVudCA9IGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKGlucHV0SWQpOwogIGlucHV0RWxlbWVudC5kaXNhYmxlZCA9IGZhbHNlOwoKICBjb25zdCBvdXRwdXRFbGVtZW50ID0gZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQob3V0cHV0SWQpOwogIG91dHB1dEVsZW1lbnQuaW5uZXJIVE1MID0gJyc7CgogIGNvbnN0IHBpY2tlZFByb21pc2UgPSBuZXcgUHJvbWlzZSgocmVzb2x2ZSkgPT4gewogICAgaW5wdXRFbGVtZW50LmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIChlKSA9PiB7CiAgICAgIHJlc29sdmUoZS50YXJnZXQuZmlsZXMpOwogICAgfSk7CiAgfSk7CgogIGNvbnN0IGNhbmNlbCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2J1dHRvbicpOwogIGlucHV0RWxlbWVudC5wYXJlbnRFbGVtZW50LmFwcGVuZENoaWxkKGNhbmNlbCk7CiAgY2FuY2VsLnRleHRDb250ZW50ID0gJ0NhbmNlbCB1cGxvYWQnOwogIGNvbnN0IGNhbmNlbFByb21pc2UgPSBuZXcgUHJvbWlzZSgocmVzb2x2ZSkgPT4gewogICAgY2FuY2VsLm9uY2xpY2sgPSAoKSA9PiB7CiAgICAgIHJlc29sdmUobnVsbCk7CiAgICB9OwogIH0pOwoKICAvLyBXYWl0IGZvciB0aGUgdXNlciB0byBwaWNrIHRoZSBmaWxlcy4KICBjb25zdCBmaWxlcyA9IHlpZWxkIHsKICAgIHByb21pc2U6IFByb21pc2UucmFjZShbcGlja2VkUHJvbWlzZSwgY2FuY2VsUHJvbWlzZV0pLAogICAgcmVzcG9uc2U6IHsKICAgICAgYWN0aW9uOiAnc3RhcnRpbmcnLAogICAgfQogIH07CgogIGNhbmNlbC5yZW1vdmUoKTsKCiAgLy8gRGlzYWJsZSB0aGUgaW5wdXQgZWxlbWVudCBzaW5jZSBmdXJ0aGVyIHBpY2tzIGFyZSBub3QgYWxsb3dlZC4KICBpbnB1dEVsZW1lbnQuZGlzYWJsZWQgPSB0cnVlOwoKICBpZiAoIWZpbGVzKSB7CiAgICByZXR1cm4gewogICAgICByZXNwb25zZTogewogICAgICAgIGFjdGlvbjogJ2NvbXBsZXRlJywKICAgICAgfQogICAgfTsKICB9CgogIGZvciAoY29uc3QgZmlsZSBvZiBmaWxlcykgewogICAgY29uc3QgbGkgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaScpOwogICAgbGkuYXBwZW5kKHNwYW4oZmlsZS5uYW1lLCB7Zm9udFdlaWdodDogJ2JvbGQnfSkpOwogICAgbGkuYXBwZW5kKHNwYW4oCiAgICAgICAgYCgke2ZpbGUudHlwZSB8fCAnbi9hJ30pIC0gJHtmaWxlLnNpemV9IGJ5dGVzLCBgICsKICAgICAgICBgbGFzdCBtb2RpZmllZDogJHsKICAgICAgICAgICAgZmlsZS5sYXN0TW9kaWZpZWREYXRlID8gZmlsZS5sYXN0TW9kaWZpZWREYXRlLnRvTG9jYWxlRGF0ZVN0cmluZygpIDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgJ24vYSd9IC0gYCkpOwogICAgY29uc3QgcGVyY2VudCA9IHNwYW4oJzAlIGRvbmUnKTsKICAgIGxpLmFwcGVuZENoaWxkKHBlcmNlbnQpOwoKICAgIG91dHB1dEVsZW1lbnQuYXBwZW5kQ2hpbGQobGkpOwoKICAgIGNvbnN0IGZpbGVEYXRhUHJvbWlzZSA9IG5ldyBQcm9taXNlKChyZXNvbHZlKSA9PiB7CiAgICAgIGNvbnN0IHJlYWRlciA9IG5ldyBGaWxlUmVhZGVyKCk7CiAgICAgIHJlYWRlci5vbmxvYWQgPSAoZSkgPT4gewogICAgICAgIHJlc29sdmUoZS50YXJnZXQucmVzdWx0KTsKICAgICAgfTsKICAgICAgcmVhZGVyLnJlYWRBc0FycmF5QnVmZmVyKGZpbGUpOwogICAgfSk7CiAgICAvLyBXYWl0IGZvciB0aGUgZGF0YSB0byBiZSByZWFkeS4KICAgIGxldCBmaWxlRGF0YSA9IHlpZWxkIHsKICAgICAgcHJvbWlzZTogZmlsZURhdGFQcm9taXNlLAogICAgICByZXNwb25zZTogewogICAgICAgIGFjdGlvbjogJ2NvbnRpbnVlJywKICAgICAgfQogICAgfTsKCiAgICAvLyBVc2UgYSBjaHVua2VkIHNlbmRpbmcgdG8gYXZvaWQgbWVzc2FnZSBzaXplIGxpbWl0cy4gU2VlIGIvNjIxMTU2NjAuCiAgICBsZXQgcG9zaXRpb24gPSAwOwogICAgZG8gewogICAgICBjb25zdCBsZW5ndGggPSBNYXRoLm1pbihmaWxlRGF0YS5ieXRlTGVuZ3RoIC0gcG9zaXRpb24sIE1BWF9QQVlMT0FEX1NJWkUpOwogICAgICBjb25zdCBjaHVuayA9IG5ldyBVaW50OEFycmF5KGZpbGVEYXRhLCBwb3NpdGlvbiwgbGVuZ3RoKTsKICAgICAgcG9zaXRpb24gKz0gbGVuZ3RoOwoKICAgICAgY29uc3QgYmFzZTY0ID0gYnRvYShTdHJpbmcuZnJvbUNoYXJDb2RlLmFwcGx5KG51bGwsIGNodW5rKSk7CiAgICAgIHlpZWxkIHsKICAgICAgICByZXNwb25zZTogewogICAgICAgICAgYWN0aW9uOiAnYXBwZW5kJywKICAgICAgICAgIGZpbGU6IGZpbGUubmFtZSwKICAgICAgICAgIGRhdGE6IGJhc2U2NCwKICAgICAgICB9LAogICAgICB9OwoKICAgICAgbGV0IHBlcmNlbnREb25lID0gZmlsZURhdGEuYnl0ZUxlbmd0aCA9PT0gMCA/CiAgICAgICAgICAxMDAgOgogICAgICAgICAgTWF0aC5yb3VuZCgocG9zaXRpb24gLyBmaWxlRGF0YS5ieXRlTGVuZ3RoKSAqIDEwMCk7CiAgICAgIHBlcmNlbnQudGV4dENvbnRlbnQgPSBgJHtwZXJjZW50RG9uZX0lIGRvbmVgOwoKICAgIH0gd2hpbGUgKHBvc2l0aW9uIDwgZmlsZURhdGEuYnl0ZUxlbmd0aCk7CiAgfQoKICAvLyBBbGwgZG9uZS4KICB5aWVsZCB7CiAgICByZXNwb25zZTogewogICAgICBhY3Rpb246ICdjb21wbGV0ZScsCiAgICB9CiAgfTsKfQoKc2NvcGUuZ29vZ2xlID0gc2NvcGUuZ29vZ2xlIHx8IHt9OwpzY29wZS5nb29nbGUuY29sYWIgPSBzY29wZS5nb29nbGUuY29sYWIgfHwge307CnNjb3BlLmdvb2dsZS5jb2xhYi5fZmlsZXMgPSB7CiAgX3VwbG9hZEZpbGVzLAogIF91cGxvYWRGaWxlc0NvbnRpbnVlLAp9Owp9KShzZWxmKTsK",
-       "headers": [
-        [
-         "content-type",
-         "application/javascript"
-        ]
-       ],
-       "ok": true,
-       "status": 200,
-       "status_text": ""
-      }
-     }
-    },
-    "id": "5J5QMVNSHFmf",
-    "outputId": "c585d658-e5ab-4853-d040-c56718d10818"
-   },
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/html": [
-       "\n",
-       "     <input type=\"file\" id=\"files-4f2e4b5f-3130-48d6-a8e8-84eac98b8d5e\" name=\"files[]\" multiple disabled\n",
-       "        style=\"border:none\" />\n",
-       "     <output id=\"result-4f2e4b5f-3130-48d6-a8e8-84eac98b8d5e\">\n",
-       "      Upload widget is only available when the cell has been executed in the\n",
-       "      current browser session. Please rerun this cell to enable.\n",
-       "      </output>\n",
-       "      <script src=\"/nbextensions/google.colab/files.js\"></script> "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saving jsl_keys.json to jsl_keys.json\n"
-     ]
-    }
-   ],
-   "source": [
-    "import json\n",
-    "import os\n",
-    "\n",
-    "from google.colab import files\n",
-    "\n",
-    "license_keys = files.upload()\n",
-    "\n",
-    "with open(list(license_keys.keys())[0]) as f:\n",
-    "    license_keys = json.load(f)\n",
-    "\n",
-    "# Defining license key-value pairs as local variables\n",
-    "locals().update(license_keys)\n",
-    "\n",
-    "# Adding license key-value pairs to environment variables\n",
-    "os.environ.update(license_keys)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "kilg7TU4HPSY",
-    "outputId": "e6d01d48-a79d-48a4-e984-b365fe6bb919"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[K     |████████████████████████████████| 212.4 MB 72 kB/s \n",
-      "\u001b[K     |████████████████████████████████| 130 kB 44.1 MB/s \n",
-      "\u001b[K     |████████████████████████████████| 198 kB 48.1 MB/s \n",
-      "\u001b[?25h  Building wheel for pyspark (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-      "\u001b[K     |████████████████████████████████| 136 kB 5.0 MB/s \n",
-      "\u001b[K     |████████████████████████████████| 95 kB 2.4 MB/s \n",
-      "\u001b[K     |████████████████████████████████| 66 kB 3.7 MB/s \n",
-      "\u001b[?25h"
-     ]
-    }
-   ],
-   "source": [
-    "# Installing pyspark and spark-nlp\n",
-    "! pip install --upgrade -q pyspark==3.1.2 spark-nlp==$PUBLIC_VERSION\n",
-    "\n",
-    "# Installing Spark NLP Healthcare\n",
-    "! pip install --upgrade -q spark-nlp-jsl==$JSL_VERSION  --extra-index-url https://pypi.johnsnowlabs.com/$SECRET\n",
-    "\n",
-    "# Installing Spark NLP Display Library for visualization\n",
-    "! pip install -q spark-nlp-display"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 271
-    },
-    "id": "_gzYc9fBVH8C",
-    "outputId": "c56ba1ed-60c7-4ac6-b19f-7e68ce2bb484"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Spark NLP Version : 3.3.2\n",
-      "Spark NLP_JSL Version : 3.3.2\n",
-      "Warning::Spark Session already created, some configs may not take.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <div>\n",
-       "                <p><b>SparkSession - in-memory</b></p>\n",
-       "                \n",
-       "        <div>\n",
-       "            <p><b>SparkContext</b></p>\n",
-       "\n",
-       "            <p><a href=\"http://f5cc1c6f8d72:4040\">Spark UI</a></p>\n",
-       "\n",
-       "            <dl>\n",
-       "              <dt>Version</dt>\n",
-       "                <dd><code>v3.1.2</code></dd>\n",
-       "              <dt>Master</dt>\n",
-       "                <dd><code>local[*]</code></dd>\n",
-       "              <dt>AppName</dt>\n",
-       "                <dd><code>Spark NLP Licensed</code></dd>\n",
-       "            </dl>\n",
-       "        </div>\n",
-       "        \n",
-       "            </div>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<pyspark.sql.session.SparkSession at 0x7f61a0752890>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import pandas as pd\n",
-    "import requests\n",
-    "import json\n",
-    "from zipfile import ZipFile\n",
-    "from io import BytesIO\n",
-    "import os\n",
-    "from pyspark.ml import Pipeline,PipelineModel\n",
-    "from pyspark.sql import SparkSession\n",
-    "from pyspark.sql import functions as F\n",
-    "\n",
-    "from sparknlp.annotator import *\n",
-    "from sparknlp_jsl.annotator import *\n",
-    "from sparknlp.base import *\n",
-    "import sparknlp_jsl\n",
-    "import sparknlp\n",
-    "\n",
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
-    "\n",
-    "params = {\"spark.driver.memory\":\"16G\", \n",
-    "          \"spark.kryoserializer.buffer.max\":\"2000M\", \n",
-    "          \"spark.driver.maxResultSize\":\"2000M\"} \n",
-    "\n",
-    "print (\"Spark NLP Version :\", sparknlp.version())\n",
-    "print (\"Spark NLP_JSL Version :\", sparknlp_jsl.version())\n",
-    "\n",
-    "spark = sparknlp_jsl.start(license_keys['SECRET'],params=params)\n",
-    "\n",
-    "spark"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "sIijfVRHVH8G"
-   },
-   "source": [
-    "**Note: The base url for this demo is: https://annotationlab.johnsnowlabs.com - you can change this accordingly**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "k7RkDZKNbEsX"
-   },
-   "source": [
-    "**Provide you user credentials**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {
-    "id": "QHcR4IBqa_tA"
-   },
-   "outputs": [],
-   "source": [
-    "username = 'user'\n",
-    "password = 'pass'\n",
-    "client_secret = \"secret\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Ql-Hs0yzVH8H"
-   },
-   "source": [
-    "**Helper Function to get cookies**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "XGQqgAIRVH8I",
-    "outputId": "584ab7b6-b60c-4a8d-bb61-77aa688b2fff",
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "200\n"
-     ]
-    }
-   ],
-   "source": [
-    "def get_cookies(username, password):\n",
-    "    \n",
-    "    \n",
-    "    url = \"https://annotationlab.johnsnowlabs.com/openid-connect/token\"\n",
-    "    \n",
-    "    headers = {\n",
-    "        \"Content-Type\": \"application/json\",\n",
-    "        \"accept\": \"*/*\",\n",
-    "    }\n",
-    "    \n",
-    "    data = {\n",
-    "      \"username\": username,\n",
-    "      \"password\": password,\n",
-    "      \"client_id\": \"annotator\",\n",
-    "      \"client_secret\": client_secret\n",
-    "    }\n",
-    "    \n",
-    "    resp = requests.post(url, headers=headers, json=data)\n",
-    "    print (resp.status_code)\n",
-    "    auth_info = resp.json()\n",
-    "\n",
-    "    cookies = {\n",
-    "        'access_token': f\"Bearer {auth_info['access_token']}\",\n",
-    "        'refresh_token': auth_info['refresh_token']\n",
-    "    }\n",
-    "    return cookies\n",
-    "\n",
-    "cookies = get_cookies(username, password)\n",
-    "#cookies"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "QkkJwmEqVH8I"
-   },
-   "source": [
-    "# Download sample data for uploading to Alab"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "id": "YbMedxfWVH8J"
-   },
-   "outputs": [],
-   "source": [
-    "# Downloading sample datasets.\n",
-    "! wget -q https://raw.githubusercontent.com/JohnSnowLabs/spark-nlp-workshop/master/tutorials/Certification_Trainings/Healthcare/data/mt_samples.csv\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 224
-    },
-    "id": "1zZg2j0dVH8J",
-    "outputId": "0a106271-604e-4dd9-f5da-a5a626cb7891"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(50, 1)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>text</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                text\n",
-       "0  Sample Type / Medical Specialty:\\nHematology -...\n",
-       "1  Sample Type / Medical Specialty:\\nHematology -...\n",
-       "2  Sample Type / Medical Specialty:\\nHematology -...\n",
-       "3  Sample Type / Medical Specialty:\\nHematology -...\n",
-       "4  Sample Type / Medical Specialty:\\nHematology -..."
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sample_data = pd.read_csv('mt_samples.csv')\n",
-    "print (sample_data.shape)\n",
-    "sample_data.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "wSZVXEZAVH8K"
-   },
-   "source": [
-    "# 1. Pre-annotate, and upload to a project on Alab\n",
-    "\n",
-    "**Note: Your project configuration should be coherent with your pre-annotation pipeline**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "lXqhEvreVH8L"
-   },
-   "source": [
-    "**1.1 Pipeline for pre-annotation. You can change according to requirements.**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "YLnh_EgRVH8L",
-    "outputId": "ca7e64e4-38d9-4b07-96a6-5fa2799fc438"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "embeddings_clinical download started this may take some time.\n",
-      "Approximate size to download 1.6 GB\n",
-      "[OK!]\n",
-      "ner_jsl download started this may take some time.\n",
-      "Approximate size to download 14.5 MB\n",
-      "[OK!]\n",
-      "assertion_dl download started this may take some time.\n",
-      "Approximate size to download 1.3 MB\n",
-      "[OK!]\n"
-     ]
-    }
-   ],
-   "source": [
-    "document = DocumentAssembler()\\\n",
-    "    .setInputCol(\"text\")\\\n",
-    "    .setOutputCol(\"document\")\n",
-    "\n",
-    "sentence = SentenceDetector()\\\n",
-    "    .setInputCols(['document'])\\\n",
-    "    .setOutputCol('sentence')\\\n",
-    "    .setCustomBounds(['\\n'])\n",
-    "\n",
-    "tokenizer = Tokenizer() \\\n",
-    "    .setInputCols([\"sentence\"]) \\\n",
-    "    .setOutputCol(\"token\")\\\n",
-    "    .setSplitChars(['\\[','\\]'])\\\n",
-    "    .setContextChars([\".\", \",\", \";\", \":\", \"!\", \"?\", \"*\", \"-\", \"(\", \")\", \"\\\"\", \"'\",\"+\",\"%\",\"-\"])\n",
-    "\n",
-    "word_embeddings = WordEmbeddingsModel().pretrained('embeddings_clinical', 'en', 'clinical/models')\\\n",
-    "    .setInputCols([\"sentence\", 'token']) \\\n",
-    "    .setOutputCol(\"embeddings\")\\\n",
-    "\n",
-    "ner_model = MedicalNerModel.pretrained('ner_jsl', 'en', 'clinical/models')\\\n",
-    "    .setInputCols([\"sentence\", \"token\", \"embeddings\"])\\\n",
-    "    .setOutputCol(\"ner\")\n",
-    "\n",
-    "converter = NerConverter()\\\n",
-    "    .setInputCols([\"sentence\", \"token\", \"ner\"])\\\n",
-    "    .setOutputCol(\"ner_chunk\")\n",
-    "\n",
-    "assertion_model = AssertionDLModel().pretrained('assertion_dl', 'en', 'clinical/models')\\\n",
-    "    .setInputCols([\"sentence\", \"ner_chunk\", 'embeddings'])\\\n",
-    "    .setOutputCol(\"assertion_res\")\n",
-    "\n",
-    "ner_pipeline = Pipeline(\n",
-    "    stages = [\n",
-    "        document,\n",
-    "        sentence,\n",
-    "        tokenizer,\n",
-    "        word_embeddings,\n",
-    "        ner_model,\n",
-    "        converter,\n",
-    "        assertion_model\n",
-    "    ])\n",
-    "\n",
-    "empty_data = spark.createDataFrame([['']]).toDF(\"text\")\n",
-    "pipeline_model = ner_pipeline.fit(empty_data)\n",
-    "lmodel = LightPipeline(pipeline_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "zreCQgDFVH8M"
-   },
-   "source": [
-    "**1.2 Get Pre-Annotations using the pipeline above and convert to required format**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "R_GQtfPJVH8N",
-    "outputId": "b219cd72-52ae-499b-afb3-c2b8409281a4"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "50  documents will be preannotated ...\n",
-      "created spark dataframe ... transforming started\n",
-      "pandas conversion started\n"
-     ]
-    }
-   ],
-   "source": [
-    "from pyspark.sql.types import *\n",
-    "\n",
-    "def get_preannotations_from_NER (list_of_files, ner_prediction_model):\n",
-    "    \n",
-    "    print (len(list_of_files), \" documents will be preannotated ...\")\n",
-    "    \n",
-    "    file_text_tuples = []\n",
-    "    for index, file_text in enumerate(list_of_files):\n",
-    "        ## \n",
-    "        file_text_tuples.append((index, # id of the file\n",
-    "                                 'demo_mt_samples_{}'.format(index), # this is the title that appears on the UI\n",
-    "                                 file_text # text of the file\n",
-    "                                ))\n",
-    "        \n",
-    "    # Define schema\n",
-    "    schema = StructType([\n",
-    "        StructField(\"task_id\", StringType(), True),\n",
-    "        StructField(\"title\", StringType(), True),\n",
-    "        StructField(\"text\", StringType(), True)\n",
-    "    ])\n",
-    "\n",
-    "    # Create dataframe\n",
-    "    \n",
-    "    spark_df = spark.createDataFrame(file_text_tuples, schema)\n",
-    "    \n",
-    "    print (\"created spark dataframe ... transforming started\")\n",
-    "        \n",
-    "    pred_df = ner_prediction_model.transform(spark_df)\n",
-    "    \n",
-    "    print (\"pandas conversion started\")\n",
-    "    \n",
-    "    view_df = pred_df.select(\"task_id\",\n",
-    "                             'title', \n",
-    "                             \"text\",\n",
-    "                             \"ner_chunk\", ## you can change this to any column name (the final chunk column in your pp)\n",
-    "                             \"assertion_res\" # - if you want assertion annotations as well\n",
-    "                            ).toPandas()\n",
-    "    \n",
-    "        \n",
-    "    view_df['task_id']=view_df['task_id'].astype(int)\n",
-    "    \n",
-    "    return view_df\n",
-    "\n",
-    "preds_df = get_preannotations_from_NER(sample_data['text'].values, pipeline_model)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "vC0tuOo6VH8N"
-   },
-   "source": [
-    "**1.3 Prepare the JSON to upload to Alab**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "ZK3OHDtIVH8O",
-    "outputId": "1e16df7a-9759-4672-aada-f5d2b7a19292"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Annotations payload is ready\n",
-      "Annotated Documents: 50\n"
-     ]
-    }
-   ],
-   "source": [
-    "import random as rand\n",
-    "import datetime\n",
-    "\n",
-    "def generate_hash(length=10):    \n",
-    "    nums = list(range(48,58))\n",
-    "    uppers = list(range(65,91))\n",
-    "    lowers = list(range(97,123))\n",
-    "    all_chars = nums+uppers+lowers\n",
-    "    return \"\".join([chr(all_chars[rand.randint(0, len(all_chars)-1)]) for x in range(length)])\n",
-    "\n",
-    "def create_import_json (username, pandas_pred_df, project_id):\n",
-    "    \n",
-    "    def build_label(chunk, start, end, label):\n",
-    "        \n",
-    "        label_json = {\n",
-    "                \"from_name\": \"label\",\n",
-    "                \"id\": generate_hash(),\n",
-    "                \"source\": \"$text\",\n",
-    "                \"to_name\": \"text\",\n",
-    "                \"type\": \"labels\",\n",
-    "                \"value\": {\n",
-    "                  \"end\": end,\n",
-    "                  \"labels\": [label],\n",
-    "                  \"start\": start,\n",
-    "                  \"text\": chunk\n",
-    "                }\n",
-    "              }\n",
-    "        return label_json\n",
-    "\n",
-    "    import_json = []\n",
-    "\n",
-    "    for i,row in pandas_pred_df.iterrows():\n",
-    "       \n",
-    "        results_jsons = [] \n",
-    "        \n",
-    "        assertion_mapper = {}\n",
-    "        for x in row[\"ner_chunk\"]: # assign proper column name\n",
-    "            if not pd.isna(x):\n",
-    "                results_jsons.append(build_label(x.result, x.begin, x.end+1, x.metadata[\"entity\"]))\n",
-    "                assertion_mapper[x.begin] = x.result\n",
-    "                \n",
-    "        # comment out this loop if assertion is not required\n",
-    "        for x in row[\"assertion_res\"]:\n",
-    "            if not pd.isna(x):\n",
-    "                results_jsons.append(build_label(assertion_mapper[x.begin], x.begin, x.end+1, x.result))\n",
-    "                \n",
-    "             \n",
-    "        import_json.append({\"predictions\": [{\n",
-    "            'created_username': username,\n",
-    "                \"result\":results_jsons\n",
-    "            }],\n",
-    "            \"data\":{\n",
-    "                \"text\":row[\"text\"],\n",
-    "                \"title\":row['title']\n",
-    "            },\n",
-    "                            'id':row['task_id']\n",
-    "                           })\n",
-    "    \n",
-    "    print (\"Annotations payload is ready\")\n",
-    "    \n",
-    "    return import_json\n",
-    "\n",
-    "annotation_json = create_import_json('ner_jsl', preds_df, 'demo_100')\n",
-    "\n",
-    "print ('Annotated Documents:' , len(annotation_json))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "8RcutO2iVH8O"
-   },
-   "source": [
-    "**1.4 Upload pre-annotations to Alab**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 105
-    },
-    "id": "pfdZaAvHVH8O",
-    "outputId": "40a96d64-49ec-4a1a-b8b7-280c2c385cf9"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://annotationlab.johnsnowlabs.com/api/projects/demo_100/import\n",
-      "200\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.google.colaboratory.intrinsic+json": {
-       "type": "string"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "CQh3RbMfgTl2"
       },
-      "text/plain": [
-       "'{\"completion_count\":0,\"duration\":6.411985635757446,\"failed_count\":0,\"ignored_count\":0,\"prediction_count\":50,\"task_count\":50,\"task_ids\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49],\"task_title_warning\":0,\"updated_count\":0}\\n'"
+      "source": [
+        "![JohnSnowLabs](https://nlp.johnsnowlabs.com/assets/images/logo.png)"
       ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "project_name = 'demo_100'\n",
-    "url = \"https://annotationlab.johnsnowlabs.com/api/projects/{}/import\".format(project_name)\n",
-    "print (url)\n",
-    "\n",
-    "headers = {\n",
-    "        \"Content-Type\": \"application/json\",\n",
-    "        \"accept\": \"*/*\"\n",
-    "    }\n",
-    "\n",
-    "cookies = get_cookies(username, password)\n",
-    "\n",
-    "resp = requests.post(url, headers = headers, cookies = cookies, json = annotation_json)\n",
-    "\n",
-    "resp.status_code\n",
-    "resp.text"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "GNRDzyhmVH8P"
-   },
-   "source": [
-    "# 2. Download / Export a project as json from Alab"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "-NCcKmLqhEAa"
-   },
-   "source": [
-    "**2.1 Export project from Alab**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "mnNVex2FVH8P",
-    "outputId": "8d5c5ce3-0923-432b-d768-22062d6f84de",
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://annotationlab.johnsnowlabs.com/api/projects/demo_100/export?format=JSON\n",
-      "200\n",
-      "Total tasks in the project with completions: 4\n"
-     ]
-    }
-   ],
-   "source": [
-    "project_name = 'demo_100'\n",
-    "url = \"https://annotationlab.johnsnowlabs.com/api/projects/{}/export?format=JSON\".format(project_name)\n",
-    "print (url)\n",
-    "\n",
-    "headers = {\n",
-    "        \"Content-Type\": \"application/json\",\n",
-    "        \"accept\": \"*/*\"\n",
-    "    }\n",
-    "\n",
-    "cookies = get_cookies(username, password)\n",
-    "\n",
-    "resp = requests.post(url, headers = headers, cookies = cookies)\n",
-    "\n",
-    "zipfile = ZipFile(BytesIO(resp.content))\n",
-    "with zipfile.open(zipfile.namelist()[0]) as f:  \n",
-    "    data = f.read()  \n",
-    "project_json = json.loads(data)  \n",
-    "\n",
-    "print ('Total tasks in the project with completions:', len(project_json))\n",
-    "\n",
-    "with open('project_export.json', 'w') as f_:\n",
-    "    f_.write(json.dumps(project_json, indent=4))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "93UnENybjKH7"
-   },
-   "source": [
-    "**2.1 Parse the project json**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {
-    "id": "i8chf7-dgGFl"
-   },
-   "outputs": [],
-   "source": [
-    "from sparknlp_jsl.training import *\n",
-    "from pyspark.sql import functions as F\n",
-    "\n",
-    "json_path = './project_export.json'\n",
-    "\n",
-    "rdr = AnnotationToolJsonReader(assertion_labels = ['present', 'absent', 'possbile', 'hypothetical', 'conditional', 'associated_with_someone_else'])\n",
-    "\n",
-    "df_anns = rdr.readDataset(spark, json_path).withColumn(\"json\",F.lit(json_path))\n",
-    "\n",
-    "df_anns = NerConverter().setInputCols(['sentence', 'token', 'ner_label']).setOutputCol('ner_chunks').transform(df_anns)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "_tsD3RfKgPAl"
-   },
-   "source": [
-    "**2.2 Generate conll file**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "3AAbbx11jDDS",
-    "outputId": "b0c3ad1f-1a7e-4b4f-d46c-dcb886c618f4"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "project  0\n",
-      "0 0\n",
-      "0 1\n",
-      "0 2\n",
-      "0 3\n",
-      "-DOCSTART- -X- -X- O\n",
-      "\n",
-      "Sample -X- -X- O\n",
-      "Type -X- -X- O\n",
-      "/ -X- -X- O\n",
-      "Medical -X- -X- O\n",
-      "Specialty -X- -X- O\n",
-      ": -X- -X- O\n",
-      "Hematology -X- -X- B-Clinical_Dept\n",
-      "- -X- -X- O\n",
-      "Oncology -X- -X- B-Clinical_Dept\n",
-      "Sample -X- -X- O\n",
-      "Name -X- -X- O\n",
-      ": -X- -X- O\n",
-      "Consult -X- -X- O\n",
-      "- -X- -X- O\n",
-      "Breast -X- -X- B-Oncological\n",
-      "Cancer -X- -X- I-Oncological\n",
-      "Description -X- -X- B-Section_Header\n",
-      ": -X- -X- I-Section_Header\n"
-     ]
-    }
-   ],
-   "source": [
-    "def df_to_conll (json_df, project_id):\n",
-    "    df = json_df.select(\"json\",\"task_id\",F.explode(F.arrays_zip('token.begin','token.end','token.result','ner_label.result',\"token.metadata\")).alias(\"cols\")) \\\n",
-    "    .select(\"json\",\"task_id\",\n",
-    "            F.expr(\"cols['0']\").alias(\"begin\"),\n",
-    "            F.expr(\"cols['1']\").alias(\"end\"),\n",
-    "            F.expr(\"cols['2']\").alias(\"token\"),\n",
-    "            F.expr(\"cols['3']\").alias(\"ner\"),\n",
-    "           F.expr(\"cols['4'].sentence\").alias(\"sentence\")).toPandas()\n",
-    "    \n",
-    "    conll_lines=[\"-DOCSTART- -X- -X- O\\n\\n\"]\n",
-    "    for j,project in enumerate(df[\"json\"].unique()):\n",
-    "        project_df = df[df[\"json\"]==project].reset_index(drop=True)\n",
-    "        print (\"project \", j)\n",
-    "        for t,task in enumerate(project_df.task_id.unique()):\n",
-    "            print (j, t)\n",
-    "            task_df = project_df[project_df.task_id==task].reset_index(drop=True)\n",
-    "            for sent in task_df.sentence.unique():\n",
-    "                #print (task, sent)\n",
-    "                sent_df = task_df[task_df.sentence==sent].sort_values(by=[\"begin\"]).reset_index(drop=True)\n",
-    "                for i,row in sent_df.iterrows():\n",
-    "                    #print (task, sent, i)\n",
-    "                    conll_lines.append(row[\"token\"]+\" -X- -X- \"+row[\"ner\"]+\"\\n\")\n",
-    "                #print (\"end of sent \")\n",
-    "                conll_lines.append(\"\\n\")\n",
-    "    with open('./project_{}_ner.conll'.format(project_id), 'w') as f:\n",
-    "        for i in conll_lines:\n",
-    "            f.write(i)\n",
-    "    return './project_{}_ner.conll'.format(project_id)\n",
-    "\n",
-    "df_to_conll(df_anns, 'demo_100')\n",
-    "\n",
-    "!head -n 20 ./project_demo_100_ner.conll\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "eWgJvL7GjbAH"
-   },
-   "source": [
-    "**2.3 Generate Data for Training Assertion Model**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 577
-    },
-    "id": "43eUjt5akJ-0",
-    "outputId": "0dff4d49-c2eb-4168-c741-32e2a73b501a"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(4, 14)\n",
-      "4\n"
-     ]
     },
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>title</th>\n",
-       "      <th>task_id</th>\n",
-       "      <th>text</th>\n",
-       "      <th>completion_id</th>\n",
-       "      <th>tool_chunk</th>\n",
-       "      <th>assertion_label</th>\n",
-       "      <th>relations</th>\n",
-       "      <th>document</th>\n",
-       "      <th>sentence</th>\n",
-       "      <th>token</th>\n",
-       "      <th>ner_label</th>\n",
-       "      <th>ner_chunk</th>\n",
-       "      <th>json</th>\n",
-       "      <th>ner_chunks</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>demo_mt_samples_46</td>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>46001</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
-       "      <td>[(assertion, 33, 42, present, {'chunk_id': 'IY...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>[(document, 0, 10211, Sample Type / Medical Sp...</td>\n",
-       "      <td>[(document, 0, 189, Sample Type / Medical Spec...</td>\n",
-       "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
-       "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "      <td>./project_export.json</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>demo_mt_samples_47</td>\n",
-       "      <td>47</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>47001</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
-       "      <td>[(assertion, 33, 42, present, {'chunk_id': '8P...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>[(document, 0, 3491, Sample Type / Medical Spe...</td>\n",
-       "      <td>[(document, 0, 144, Sample Type / Medical Spec...</td>\n",
-       "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
-       "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "      <td>./project_export.json</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>demo_mt_samples_48</td>\n",
-       "      <td>48</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>48001</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
-       "      <td>[(assertion, 33, 42, present, {'chunk_id': '3b...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>[(document, 0, 2863, Sample Type / Medical Spe...</td>\n",
-       "      <td>[(document, 0, 126, Sample Type / Medical Spec...</td>\n",
-       "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
-       "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "      <td>./project_export.json</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>demo_mt_samples_49</td>\n",
-       "      <td>49</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>49001</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
-       "      <td>[(assertion, 33, 42, present, {'chunk_id': 'aZ...</td>\n",
-       "      <td>[]</td>\n",
-       "      <td>[(document, 0, 5889, Sample Type / Medical Spe...</td>\n",
-       "      <td>[(document, 0, 319, Sample Type / Medical Spec...</td>\n",
-       "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
-       "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "      <td>./project_export.json</td>\n",
-       "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                title  ...                                         ner_chunks\n",
-       "1  demo_mt_samples_46  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
-       "2  demo_mt_samples_47  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
-       "3  demo_mt_samples_48  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
-       "0  demo_mt_samples_49  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
-       "\n",
-       "[4 rows x 14 columns]"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "rel_pds = df_anns.toPandas()\n",
-    "print (rel_pds.shape)\n",
-    "print (rel_pds['task_id'].nunique())\n",
-    "rel_pds = rel_pds.sort_values('completion_id').drop_duplicates('task_id', keep='last')\n",
-    "rel_pds.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "e97vwcDYjZuH",
-    "outputId": "ec70673c-f38a-4d61-8ddd-afc366985053"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "46\n",
-      "47\n",
-      "48\n",
-      "49\n",
-      "present                         634\n",
-      "absent                          300\n",
-      "hypothetical                     48\n",
-      "associated_with_someone_else     36\n",
-      "conditional                      11\n",
-      "Name: assertion_label, dtype: int64\n",
-      "(1029, 12)\n"
-     ]
-    }
-   ],
-   "source": [
-    "\n",
-    "all_tasks_assertions = []\n",
-    "all_tasks_relations = []\n",
-    "for index, group in rel_pds.groupby('task_id'):\n",
-    "    \n",
-    "    print (index)\n",
-    "    \n",
-    "    ann_chunks = pd.DataFrame( [{'chunk_id': i.metadata['chunk_id'], 'chunk': i.result, 'begin': int(i.begin), 'end': i.end, 'entity': i.metadata['entity']} for i in group['tool_chunk'].explode() ] )\n",
-    "        \n",
-    "    ner_chunks = pd.DataFrame( [{'chunk_num': ii, 'chunk': i.result, 'begin': int(i.begin), 'end': i.end, 'sentence_id': int(i.metadata['sentence'])} for ii, i in enumerate(group['ner_chunks'].explode()) ] )\n",
-    "    \n",
-    "    with_sent = pd.merge(ann_chunks[['chunk_id', 'begin', 'entity']], ner_chunks, on=['begin'], how='inner')\n",
-    "    \n",
-    "    sentences_df = pd.DataFrame( [{'sentence_id': int(i.metadata['sentence']), 'sentence': i.result, 'sent_begin': int(i.begin), 'sent_end': int(i.end)} for i in group['sentence'].explode() ] )\n",
-    "    \n",
-    "    with_sent = pd.merge(with_sent, sentences_df, on=['sentence_id'], how='inner')\n",
-    "\n",
-    "    assertion_chunks = pd.DataFrame( [{'assertion_label': i.result, 'begin': int(i.begin) } for i in group['assertion_label'].explode() ] )\n",
-    "    \n",
-    "    assertion_chunks = pd.merge(assertion_chunks, with_sent, on=['begin'], how='inner')\n",
-    "    \n",
-    "    assertion_chunks['task_id'] = index\n",
-    "    all_tasks_assertions.append(assertion_chunks)\n",
-    "        \n",
-    "all_tasks_assertions = pd.concat(all_tasks_assertions, axis=0)\n",
-    "print (all_tasks_assertions['assertion_label'].value_counts())\n",
-    "\n",
-    "all_tasks_assertions['begin'] = all_tasks_assertions['begin'] - all_tasks_assertions['sent_begin']\n",
-    "all_tasks_assertions['end'] = all_tasks_assertions['end'] - all_tasks_assertions['sent_begin']\n",
-    "\n",
-    "print (all_tasks_assertions.shape)               \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 56,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 1000
-    },
-    "id": "HJJgszFHkQXv",
-    "outputId": "c96ec30d-9693-488d-9ef4-7fdff436d8d6"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(1029, 14)\n",
-      "(1029, 14)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>task_id</th>\n",
-       "      <th>sentence</th>\n",
-       "      <th>tkn_start</th>\n",
-       "      <th>tkn_end</th>\n",
-       "      <th>chunk</th>\n",
-       "      <th>entity</th>\n",
-       "      <th>assertion_label</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>4</td>\n",
-       "      <td>4</td>\n",
-       "      <td>Hematology</td>\n",
-       "      <td>Clinical_Dept</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>6</td>\n",
-       "      <td>Oncology</td>\n",
-       "      <td>Clinical_Dept</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>7</td>\n",
-       "      <td>10</td>\n",
-       "      <td>Non-Small Cell Lung Cancer</td>\n",
-       "      <td>Oncological</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>12</td>\n",
-       "      <td>12</td>\n",
-       "      <td>Description:</td>\n",
-       "      <td>Section_Header</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>15</td>\n",
-       "      <td>18</td>\n",
-       "      <td>non-small cell lung cancer</td>\n",
-       "      <td>Oncological</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>19</td>\n",
-       "      <td>20</td>\n",
-       "      <td>stage IV</td>\n",
-       "      <td>Modifier</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
-       "      <td>21</td>\n",
-       "      <td>22</td>\n",
-       "      <td>metastatic disease</td>\n",
-       "      <td>Oncological</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>46</td>\n",
-       "      <td>At this point, he and his wife ask about wheth...</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>he</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>46</td>\n",
-       "      <td>At this point, he and his wife ask about wheth...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>5</td>\n",
-       "      <td>his</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>46</td>\n",
-       "      <td>At this point, he and his wife ask about wheth...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>6</td>\n",
-       "      <td>wife</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>46</td>\n",
-       "      <td>(Medical Transcription Sample Report)\\nREASON ...</td>\n",
-       "      <td>3</td>\n",
-       "      <td>5</td>\n",
-       "      <td>REASON FOR CONSULTATION:</td>\n",
-       "      <td>Section_Header</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>46</td>\n",
-       "      <td>(Medical Transcription Sample Report)\\nREASON ...</td>\n",
-       "      <td>8</td>\n",
-       "      <td>11</td>\n",
-       "      <td>non-small cell lung cancer</td>\n",
-       "      <td>Oncological</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
-       "      <td>46</td>\n",
-       "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
-       "      <td>0</td>\n",
-       "      <td>3</td>\n",
-       "      <td>HISTORY OF PRESENT ILLNESS:</td>\n",
-       "      <td>Section_Header</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>13</th>\n",
-       "      <td>46</td>\n",
-       "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
-       "      <td>8</td>\n",
-       "      <td>8</td>\n",
-       "      <td>47-year-old</td>\n",
-       "      <td>Age</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>46</td>\n",
-       "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
-       "      <td>9</td>\n",
-       "      <td>9</td>\n",
-       "      <td>gentleman</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>46</td>\n",
-       "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
-       "      <td>22</td>\n",
-       "      <td>22</td>\n",
-       "      <td>new</td>\n",
-       "      <td>Modifier</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>46</td>\n",
-       "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
-       "      <td>27</td>\n",
-       "      <td>28</td>\n",
-       "      <td>stage IV</td>\n",
-       "      <td>Modifier</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>46</td>\n",
-       "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
-       "      <td>29</td>\n",
-       "      <td>30</td>\n",
-       "      <td>metastatic disease</td>\n",
-       "      <td>Oncological</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>46</td>\n",
-       "      <td>ABCD and his wife state that his history goes ...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>his</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>19</th>\n",
-       "      <td>46</td>\n",
-       "      <td>ABCD and his wife state that his history goes ...</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>wife</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>20</th>\n",
-       "      <td>46</td>\n",
-       "      <td>ABCD and his wife state that his history goes ...</td>\n",
-       "      <td>6</td>\n",
-       "      <td>6</td>\n",
-       "      <td>his</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>46</td>\n",
-       "      <td>ABCD and his wife state that his history goes ...</td>\n",
-       "      <td>12</td>\n",
-       "      <td>14</td>\n",
-       "      <td>2-2-1/2 weeks ago</td>\n",
-       "      <td>RelativeDate</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>46</td>\n",
-       "      <td>ABCD and his wife state that his history goes ...</td>\n",
-       "      <td>16</td>\n",
-       "      <td>16</td>\n",
-       "      <td>he</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>46</td>\n",
-       "      <td>ABCD and his wife state that his history goes ...</td>\n",
-       "      <td>19</td>\n",
-       "      <td>19</td>\n",
-       "      <td>left-sided</td>\n",
-       "      <td>Direction</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>46</td>\n",
-       "      <td>ABCD and his wife state that his history goes ...</td>\n",
-       "      <td>20</td>\n",
-       "      <td>21</td>\n",
-       "      <td>flank pain</td>\n",
-       "      <td>Symptom</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>25</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Initially, he did not think much of this and t...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>he</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>26</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Initially, he did not think much of this and t...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>14</td>\n",
-       "      <td>did not think much of this and tried to go abo...</td>\n",
-       "      <td>Symptom</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>27</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Initially, he did not think much of this and t...</td>\n",
-       "      <td>20</td>\n",
-       "      <td>20</td>\n",
-       "      <td>pain</td>\n",
-       "      <td>Symptom</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>28</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Initially, he did not think much of this and t...</td>\n",
-       "      <td>21</td>\n",
-       "      <td>22</td>\n",
-       "      <td>gradually worsened</td>\n",
-       "      <td>Modifier</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Eventually this prompted him to present to the...</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>him</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30</th>\n",
-       "      <td>46</td>\n",
-       "      <td>Eventually this prompted him to present to the...</td>\n",
-       "      <td>8</td>\n",
-       "      <td>9</td>\n",
-       "      <td>emergency room</td>\n",
-       "      <td>Clinical_Dept</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>31</th>\n",
-       "      <td>46</td>\n",
-       "      <td>A CT scan was done there, and he was found to ...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>CT scan</td>\n",
-       "      <td>Test</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>32</th>\n",
-       "      <td>46</td>\n",
-       "      <td>A CT scan was done there, and he was found to ...</td>\n",
-       "      <td>7</td>\n",
-       "      <td>7</td>\n",
-       "      <td>he</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>33</th>\n",
-       "      <td>46</td>\n",
-       "      <td>A CT scan was done there, and he was found to ...</td>\n",
-       "      <td>13</td>\n",
-       "      <td>13</td>\n",
-       "      <td>large</td>\n",
-       "      <td>Modifier</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>34</th>\n",
-       "      <td>46</td>\n",
-       "      <td>A CT scan was done there, and he was found to ...</td>\n",
-       "      <td>14</td>\n",
-       "      <td>14</td>\n",
-       "      <td>left</td>\n",
-       "      <td>Direction</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>35</th>\n",
-       "      <td>46</td>\n",
-       "      <td>A CT scan was done there, and he was found to ...</td>\n",
-       "      <td>15</td>\n",
-       "      <td>16</td>\n",
-       "      <td>adrenal mass</td>\n",
-       "      <td>Symptom</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36</th>\n",
-       "      <td>46</td>\n",
-       "      <td>At that point, he was transferred to XYZ Hospi...</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>he</td>\n",
-       "      <td>Gender</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>37</th>\n",
-       "      <td>46</td>\n",
-       "      <td>At that point, he was transferred to XYZ Hospi...</td>\n",
-       "      <td>7</td>\n",
-       "      <td>8</td>\n",
-       "      <td>XYZ Hospital</td>\n",
-       "      <td>Clinical_Dept</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>38</th>\n",
-       "      <td>46</td>\n",
-       "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>admission</td>\n",
-       "      <td>Admission_Discharge</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>39</th>\n",
-       "      <td>46</td>\n",
-       "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>12/19/08</td>\n",
-       "      <td>Date</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>40</th>\n",
-       "      <td>46</td>\n",
-       "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>6</td>\n",
-       "      <td>CT scan</td>\n",
-       "      <td>Test</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>41</th>\n",
-       "      <td>46</td>\n",
-       "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
-       "      <td>9</td>\n",
-       "      <td>9</td>\n",
-       "      <td>chest</td>\n",
-       "      <td>External_body_part_or_region</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>42</th>\n",
-       "      <td>46</td>\n",
-       "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
-       "      <td>10</td>\n",
-       "      <td>10</td>\n",
-       "      <td>abdomen</td>\n",
-       "      <td>External_body_part_or_region</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>43</th>\n",
-       "      <td>46</td>\n",
-       "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
-       "      <td>12</td>\n",
-       "      <td>12</td>\n",
-       "      <td>pelvis</td>\n",
-       "      <td>Internal_organ_or_component</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>44</th>\n",
-       "      <td>46</td>\n",
-       "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
-       "      <td>1</td>\n",
-       "      <td>5</td>\n",
-       "      <td>CT scan of the chest</td>\n",
-       "      <td>Test</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>45</th>\n",
-       "      <td>46</td>\n",
-       "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
-       "      <td>8</td>\n",
-       "      <td>8</td>\n",
-       "      <td>abnormal</td>\n",
-       "      <td>Modifier</td>\n",
-       "      <td>absent</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>46</th>\n",
-       "      <td>46</td>\n",
-       "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
-       "      <td>14</td>\n",
-       "      <td>14</td>\n",
-       "      <td>right</td>\n",
-       "      <td>Direction</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>47</th>\n",
-       "      <td>46</td>\n",
-       "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
-       "      <td>15</td>\n",
-       "      <td>16</td>\n",
-       "      <td>paratracheal region</td>\n",
-       "      <td>External_body_part_or_region</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>48</th>\n",
-       "      <td>46</td>\n",
-       "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
-       "      <td>20</td>\n",
-       "      <td>21</td>\n",
-       "      <td>precarinal region</td>\n",
-       "      <td>Internal_organ_or_component</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>49</th>\n",
-       "      <td>46</td>\n",
-       "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
-       "      <td>23</td>\n",
-       "      <td>24</td>\n",
-       "      <td>subcarinal region</td>\n",
-       "      <td>Internal_organ_or_component</td>\n",
-       "      <td>present</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    task_id  ... assertion_label\n",
-       "0        46  ...         present\n",
-       "1        46  ...         present\n",
-       "2        46  ...         present\n",
-       "3        46  ...         present\n",
-       "4        46  ...         present\n",
-       "5        46  ...         present\n",
-       "6        46  ...         present\n",
-       "7        46  ...         present\n",
-       "8        46  ...         present\n",
-       "9        46  ...         present\n",
-       "10       46  ...         present\n",
-       "11       46  ...         present\n",
-       "12       46  ...         present\n",
-       "13       46  ...         present\n",
-       "14       46  ...         present\n",
-       "15       46  ...         present\n",
-       "16       46  ...         present\n",
-       "17       46  ...         present\n",
-       "18       46  ...          absent\n",
-       "19       46  ...          absent\n",
-       "20       46  ...          absent\n",
-       "21       46  ...         present\n",
-       "22       46  ...         present\n",
-       "23       46  ...         present\n",
-       "24       46  ...         present\n",
-       "25       46  ...         present\n",
-       "26       46  ...         present\n",
-       "27       46  ...         present\n",
-       "28       46  ...         present\n",
-       "29       46  ...         present\n",
-       "30       46  ...         present\n",
-       "31       46  ...          absent\n",
-       "32       46  ...         present\n",
-       "33       46  ...         present\n",
-       "34       46  ...         present\n",
-       "35       46  ...         present\n",
-       "36       46  ...         present\n",
-       "37       46  ...         present\n",
-       "38       46  ...          absent\n",
-       "39       46  ...          absent\n",
-       "40       46  ...         present\n",
-       "41       46  ...          absent\n",
-       "42       46  ...          absent\n",
-       "43       46  ...          absent\n",
-       "44       46  ...         present\n",
-       "45       46  ...          absent\n",
-       "46       46  ...         present\n",
-       "47       46  ...         present\n",
-       "48       46  ...         present\n",
-       "49       46  ...         present\n",
-       "\n",
-       "[50 rows x 7 columns]"
-      ]
-     },
-     "execution_count": 56,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from itertools import groupby\n",
-    "\n",
-    "def split_get_ind(str_):\n",
-    "    ret = []\n",
-    "    for k, g in groupby(enumerate(str_), lambda x: x[1] != ' '):\n",
-    "        if k:\n",
-    "            pos, first_item = next(g)\n",
-    "            res = first_item + ''.join([x for _, x in g])\n",
-    "            ret.append( (pos, pos+len(res)))\n",
-    "    return ret\n",
-    "\n",
-    "tkn_st = []\n",
-    "tkn_ed = []\n",
-    "for i, row in all_tasks_assertions.iterrows():\n",
-    "    ass_tkns = split_get_ind(row['sentence'])\n",
-    "    st = -1\n",
-    "    ed = -1\n",
-    "    for tkn_ind, tkn in enumerate(ass_tkns):\n",
-    "        if int(row['begin']) in range(*tkn):\n",
-    "            st = tkn_ind\n",
-    "        if int(row['end']) in range(*tkn):\n",
-    "            ed = tkn_ind\n",
-    "    if st < 0 or ed < 0:\n",
-    "        tkn_st.append(None)\n",
-    "        tkn_ed.append(None)\n",
-    "    else:\n",
-    "        tkn_st.append(st)\n",
-    "        tkn_ed.append(ed)\n",
-    "    \n",
-    "    #print (st, ed)\n",
-    "all_tasks_assertions['tkn_start'] = tkn_st\n",
-    "all_tasks_assertions['tkn_end'] = tkn_ed\n",
-    "print (all_tasks_assertions.shape)\n",
-    "all_tasks_assertions.dropna(inplace=True)\n",
-    "all_tasks_assertions.reset_index(inplace=True, drop=True)\n",
-    "print (all_tasks_assertions.shape)\n",
-    "all_tasks_assertions = all_tasks_assertions[['task_id', 'sentence', 'tkn_start', 'tkn_end', 'chunk', 'entity', 'assertion_label']]\n",
-    "all_tasks_assertions.head(50)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "gV6VBTQMVH8P"
-   },
-   "source": [
-    "# 3. Simply Upload data to an Alab Project (without pre-annotations)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 87
-    },
-    "id": "yjXuypwHVH8P",
-    "outputId": "0c908709-1a90-44ea-f58e-eb77d07cd03b"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "https://annotationlab.johnsnowlabs.com/api/projects/dummy/import\n",
-      "200\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.google.colaboratory.intrinsic+json": {
-       "type": "string"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TwURPTydgTl7"
       },
-      "text/plain": [
-       "'{\"code\":500,\"description\":\"The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.\",\"error\":\"Internal Server Error\"}\\n'"
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Annotation_Lab/AL_API_import_export_pre_annotate.ipynb)\n"
       ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9EQwCxr7JGh8"
+      },
+      "source": [
+        "# Connect to Annotation Lab via API.\n",
+        "## This tutorial provides instrudctions and code for the following operations:\n",
+        "- Uploading Pre-annotations to Alab\n",
+        "- Importing a project from Alab, and converting to get conll, Assertion files.\n",
+        "- Uploading tasks without pre-annotations."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 73,
+          "resources": {
+            "http://localhost:8080/nbextensions/google.colab/files.js": {
+              "data": "Ly8gQ29weXJpZ2h0IDIwMTcgR29vZ2xlIExMQwovLwovLyBMaWNlbnNlZCB1bmRlciB0aGUgQXBhY2hlIExpY2Vuc2UsIFZlcnNpb24gMi4wICh0aGUgIkxpY2Vuc2UiKTsKLy8geW91IG1heSBub3QgdXNlIHRoaXMgZmlsZSBleGNlcHQgaW4gY29tcGxpYW5jZSB3aXRoIHRoZSBMaWNlbnNlLgovLyBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKLy8KLy8gICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvTElDRU5TRS0yLjAKLy8KLy8gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQovLyBkaXN0cmlidXRlZCB1bmRlciB0aGUgTGljZW5zZSBpcyBkaXN0cmlidXRlZCBvbiBhbiAiQVMgSVMiIEJBU0lTLAovLyBXSVRIT1VUIFdBUlJBTlRJRVMgT1IgQ09ORElUSU9OUyBPRiBBTlkgS0lORCwgZWl0aGVyIGV4cHJlc3Mgb3IgaW1wbGllZC4KLy8gU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAovLyBsaW1pdGF0aW9ucyB1bmRlciB0aGUgTGljZW5zZS4KCi8qKgogKiBAZmlsZW92ZXJ2aWV3IEhlbHBlcnMgZm9yIGdvb2dsZS5jb2xhYiBQeXRob24gbW9kdWxlLgogKi8KKGZ1bmN0aW9uKHNjb3BlKSB7CmZ1bmN0aW9uIHNwYW4odGV4dCwgc3R5bGVBdHRyaWJ1dGVzID0ge30pIHsKICBjb25zdCBlbGVtZW50ID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc3BhbicpOwogIGVsZW1lbnQudGV4dENvbnRlbnQgPSB0ZXh0OwogIGZvciAoY29uc3Qga2V5IG9mIE9iamVjdC5rZXlzKHN0eWxlQXR0cmlidXRlcykpIHsKICAgIGVsZW1lbnQuc3R5bGVba2V5XSA9IHN0eWxlQXR0cmlidXRlc1trZXldOwogIH0KICByZXR1cm4gZWxlbWVudDsKfQoKLy8gTWF4IG51bWJlciBvZiBieXRlcyB3aGljaCB3aWxsIGJlIHVwbG9hZGVkIGF0IGEgdGltZS4KY29uc3QgTUFYX1BBWUxPQURfU0laRSA9IDEwMCAqIDEwMjQ7CgpmdW5jdGlvbiBfdXBsb2FkRmlsZXMoaW5wdXRJZCwgb3V0cHV0SWQpIHsKICBjb25zdCBzdGVwcyA9IHVwbG9hZEZpbGVzU3RlcChpbnB1dElkLCBvdXRwdXRJZCk7CiAgY29uc3Qgb3V0cHV0RWxlbWVudCA9IGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKG91dHB1dElkKTsKICAvLyBDYWNoZSBzdGVwcyBvbiB0aGUgb3V0cHV0RWxlbWVudCB0byBtYWtlIGl0IGF2YWlsYWJsZSBmb3IgdGhlIG5leHQgY2FsbAogIC8vIHRvIHVwbG9hZEZpbGVzQ29udGludWUgZnJvbSBQeXRob24uCiAgb3V0cHV0RWxlbWVudC5zdGVwcyA9IHN0ZXBzOwoKICByZXR1cm4gX3VwbG9hZEZpbGVzQ29udGludWUob3V0cHV0SWQpOwp9CgovLyBUaGlzIGlzIHJvdWdobHkgYW4gYXN5bmMgZ2VuZXJhdG9yIChub3Qgc3VwcG9ydGVkIGluIHRoZSBicm93c2VyIHlldCksCi8vIHdoZXJlIHRoZXJlIGFyZSBtdWx0aXBsZSBhc3luY2hyb25vdXMgc3RlcHMgYW5kIHRoZSBQeXRob24gc2lkZSBpcyBnb2luZwovLyB0byBwb2xsIGZvciBjb21wbGV0aW9uIG9mIGVhY2ggc3RlcC4KLy8gVGhpcyB1c2VzIGEgUHJvbWlzZSB0byBibG9jayB0aGUgcHl0aG9uIHNpZGUgb24gY29tcGxldGlvbiBvZiBlYWNoIHN0ZXAsCi8vIHRoZW4gcGFzc2VzIHRoZSByZXN1bHQgb2YgdGhlIHByZXZpb3VzIHN0ZXAgYXMgdGhlIGlucHV0IHRvIHRoZSBuZXh0IHN0ZXAuCmZ1bmN0aW9uIF91cGxvYWRGaWxlc0NvbnRpbnVlKG91dHB1dElkKSB7CiAgY29uc3Qgb3V0cHV0RWxlbWVudCA9IGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKG91dHB1dElkKTsKICBjb25zdCBzdGVwcyA9IG91dHB1dEVsZW1lbnQuc3RlcHM7CgogIGNvbnN0IG5leHQgPSBzdGVwcy5uZXh0KG91dHB1dEVsZW1lbnQubGFzdFByb21pc2VWYWx1ZSk7CiAgcmV0dXJuIFByb21pc2UucmVzb2x2ZShuZXh0LnZhbHVlLnByb21pc2UpLnRoZW4oKHZhbHVlKSA9PiB7CiAgICAvLyBDYWNoZSB0aGUgbGFzdCBwcm9taXNlIHZhbHVlIHRvIG1ha2UgaXQgYXZhaWxhYmxlIHRvIHRoZSBuZXh0CiAgICAvLyBzdGVwIG9mIHRoZSBnZW5lcmF0b3IuCiAgICBvdXRwdXRFbGVtZW50Lmxhc3RQcm9taXNlVmFsdWUgPSB2YWx1ZTsKICAgIHJldHVybiBuZXh0LnZhbHVlLnJlc3BvbnNlOwogIH0pOwp9CgovKioKICogR2VuZXJhdG9yIGZ1bmN0aW9uIHdoaWNoIGlzIGNhbGxlZCBiZXR3ZWVuIGVhY2ggYXN5bmMgc3RlcCBvZiB0aGUgdXBsb2FkCiAqIHByb2Nlc3MuCiAqIEBwYXJhbSB7c3RyaW5nfSBpbnB1dElkIEVsZW1lbnQgSUQgb2YgdGhlIGlucHV0IGZpbGUgcGlja2VyIGVsZW1lbnQuCiAqIEBwYXJhbSB7c3RyaW5nfSBvdXRwdXRJZCBFbGVtZW50IElEIG9mIHRoZSBvdXRwdXQgZGlzcGxheS4KICogQHJldHVybiB7IUl0ZXJhYmxlPCFPYmplY3Q+fSBJdGVyYWJsZSBvZiBuZXh0IHN0ZXBzLgogKi8KZnVuY3Rpb24qIHVwbG9hZEZpbGVzU3RlcChpbnB1dElkLCBvdXRwdXRJZCkgewogIGNvbnN0IGlucHV0RWxlbWVudCA9IGRvY3VtZW50LmdldEVsZW1lbnRCeUlkKGlucHV0SWQpOwogIGlucHV0RWxlbWVudC5kaXNhYmxlZCA9IGZhbHNlOwoKICBjb25zdCBvdXRwdXRFbGVtZW50ID0gZG9jdW1lbnQuZ2V0RWxlbWVudEJ5SWQob3V0cHV0SWQpOwogIG91dHB1dEVsZW1lbnQuaW5uZXJIVE1MID0gJyc7CgogIGNvbnN0IHBpY2tlZFByb21pc2UgPSBuZXcgUHJvbWlzZSgocmVzb2x2ZSkgPT4gewogICAgaW5wdXRFbGVtZW50LmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIChlKSA9PiB7CiAgICAgIHJlc29sdmUoZS50YXJnZXQuZmlsZXMpOwogICAgfSk7CiAgfSk7CgogIGNvbnN0IGNhbmNlbCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2J1dHRvbicpOwogIGlucHV0RWxlbWVudC5wYXJlbnRFbGVtZW50LmFwcGVuZENoaWxkKGNhbmNlbCk7CiAgY2FuY2VsLnRleHRDb250ZW50ID0gJ0NhbmNlbCB1cGxvYWQnOwogIGNvbnN0IGNhbmNlbFByb21pc2UgPSBuZXcgUHJvbWlzZSgocmVzb2x2ZSkgPT4gewogICAgY2FuY2VsLm9uY2xpY2sgPSAoKSA9PiB7CiAgICAgIHJlc29sdmUobnVsbCk7CiAgICB9OwogIH0pOwoKICAvLyBXYWl0IGZvciB0aGUgdXNlciB0byBwaWNrIHRoZSBmaWxlcy4KICBjb25zdCBmaWxlcyA9IHlpZWxkIHsKICAgIHByb21pc2U6IFByb21pc2UucmFjZShbcGlja2VkUHJvbWlzZSwgY2FuY2VsUHJvbWlzZV0pLAogICAgcmVzcG9uc2U6IHsKICAgICAgYWN0aW9uOiAnc3RhcnRpbmcnLAogICAgfQogIH07CgogIGNhbmNlbC5yZW1vdmUoKTsKCiAgLy8gRGlzYWJsZSB0aGUgaW5wdXQgZWxlbWVudCBzaW5jZSBmdXJ0aGVyIHBpY2tzIGFyZSBub3QgYWxsb3dlZC4KICBpbnB1dEVsZW1lbnQuZGlzYWJsZWQgPSB0cnVlOwoKICBpZiAoIWZpbGVzKSB7CiAgICByZXR1cm4gewogICAgICByZXNwb25zZTogewogICAgICAgIGFjdGlvbjogJ2NvbXBsZXRlJywKICAgICAgfQogICAgfTsKICB9CgogIGZvciAoY29uc3QgZmlsZSBvZiBmaWxlcykgewogICAgY29uc3QgbGkgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdsaScpOwogICAgbGkuYXBwZW5kKHNwYW4oZmlsZS5uYW1lLCB7Zm9udFdlaWdodDogJ2JvbGQnfSkpOwogICAgbGkuYXBwZW5kKHNwYW4oCiAgICAgICAgYCgke2ZpbGUudHlwZSB8fCAnbi9hJ30pIC0gJHtmaWxlLnNpemV9IGJ5dGVzLCBgICsKICAgICAgICBgbGFzdCBtb2RpZmllZDogJHsKICAgICAgICAgICAgZmlsZS5sYXN0TW9kaWZpZWREYXRlID8gZmlsZS5sYXN0TW9kaWZpZWREYXRlLnRvTG9jYWxlRGF0ZVN0cmluZygpIDoKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgJ24vYSd9IC0gYCkpOwogICAgY29uc3QgcGVyY2VudCA9IHNwYW4oJzAlIGRvbmUnKTsKICAgIGxpLmFwcGVuZENoaWxkKHBlcmNlbnQpOwoKICAgIG91dHB1dEVsZW1lbnQuYXBwZW5kQ2hpbGQobGkpOwoKICAgIGNvbnN0IGZpbGVEYXRhUHJvbWlzZSA9IG5ldyBQcm9taXNlKChyZXNvbHZlKSA9PiB7CiAgICAgIGNvbnN0IHJlYWRlciA9IG5ldyBGaWxlUmVhZGVyKCk7CiAgICAgIHJlYWRlci5vbmxvYWQgPSAoZSkgPT4gewogICAgICAgIHJlc29sdmUoZS50YXJnZXQucmVzdWx0KTsKICAgICAgfTsKICAgICAgcmVhZGVyLnJlYWRBc0FycmF5QnVmZmVyKGZpbGUpOwogICAgfSk7CiAgICAvLyBXYWl0IGZvciB0aGUgZGF0YSB0byBiZSByZWFkeS4KICAgIGxldCBmaWxlRGF0YSA9IHlpZWxkIHsKICAgICAgcHJvbWlzZTogZmlsZURhdGFQcm9taXNlLAogICAgICByZXNwb25zZTogewogICAgICAgIGFjdGlvbjogJ2NvbnRpbnVlJywKICAgICAgfQogICAgfTsKCiAgICAvLyBVc2UgYSBjaHVua2VkIHNlbmRpbmcgdG8gYXZvaWQgbWVzc2FnZSBzaXplIGxpbWl0cy4gU2VlIGIvNjIxMTU2NjAuCiAgICBsZXQgcG9zaXRpb24gPSAwOwogICAgZG8gewogICAgICBjb25zdCBsZW5ndGggPSBNYXRoLm1pbihmaWxlRGF0YS5ieXRlTGVuZ3RoIC0gcG9zaXRpb24sIE1BWF9QQVlMT0FEX1NJWkUpOwogICAgICBjb25zdCBjaHVuayA9IG5ldyBVaW50OEFycmF5KGZpbGVEYXRhLCBwb3NpdGlvbiwgbGVuZ3RoKTsKICAgICAgcG9zaXRpb24gKz0gbGVuZ3RoOwoKICAgICAgY29uc3QgYmFzZTY0ID0gYnRvYShTdHJpbmcuZnJvbUNoYXJDb2RlLmFwcGx5KG51bGwsIGNodW5rKSk7CiAgICAgIHlpZWxkIHsKICAgICAgICByZXNwb25zZTogewogICAgICAgICAgYWN0aW9uOiAnYXBwZW5kJywKICAgICAgICAgIGZpbGU6IGZpbGUubmFtZSwKICAgICAgICAgIGRhdGE6IGJhc2U2NCwKICAgICAgICB9LAogICAgICB9OwoKICAgICAgbGV0IHBlcmNlbnREb25lID0gZmlsZURhdGEuYnl0ZUxlbmd0aCA9PT0gMCA/CiAgICAgICAgICAxMDAgOgogICAgICAgICAgTWF0aC5yb3VuZCgocG9zaXRpb24gLyBmaWxlRGF0YS5ieXRlTGVuZ3RoKSAqIDEwMCk7CiAgICAgIHBlcmNlbnQudGV4dENvbnRlbnQgPSBgJHtwZXJjZW50RG9uZX0lIGRvbmVgOwoKICAgIH0gd2hpbGUgKHBvc2l0aW9uIDwgZmlsZURhdGEuYnl0ZUxlbmd0aCk7CiAgfQoKICAvLyBBbGwgZG9uZS4KICB5aWVsZCB7CiAgICByZXNwb25zZTogewogICAgICBhY3Rpb246ICdjb21wbGV0ZScsCiAgICB9CiAgfTsKfQoKc2NvcGUuZ29vZ2xlID0gc2NvcGUuZ29vZ2xlIHx8IHt9OwpzY29wZS5nb29nbGUuY29sYWIgPSBzY29wZS5nb29nbGUuY29sYWIgfHwge307CnNjb3BlLmdvb2dsZS5jb2xhYi5fZmlsZXMgPSB7CiAgX3VwbG9hZEZpbGVzLAogIF91cGxvYWRGaWxlc0NvbnRpbnVlLAp9Owp9KShzZWxmKTsK",
+              "headers": [
+                [
+                  "content-type",
+                  "application/javascript"
+                ]
+              ],
+              "ok": true,
+              "status": 200,
+              "status_text": ""
+            }
+          }
+        },
+        "id": "5J5QMVNSHFmf",
+        "outputId": "c585d658-e5ab-4853-d040-c56718d10818"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "     <input type=\"file\" id=\"files-4f2e4b5f-3130-48d6-a8e8-84eac98b8d5e\" name=\"files[]\" multiple disabled\n",
+              "        style=\"border:none\" />\n",
+              "     <output id=\"result-4f2e4b5f-3130-48d6-a8e8-84eac98b8d5e\">\n",
+              "      Upload widget is only available when the cell has been executed in the\n",
+              "      current browser session. Please rerun this cell to enable.\n",
+              "      </output>\n",
+              "      <script src=\"/nbextensions/google.colab/files.js\"></script> "
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Saving jsl_keys.json to jsl_keys.json\n"
+          ]
+        }
+      ],
+      "source": [
+        "import json\n",
+        "import os\n",
+        "\n",
+        "from google.colab import files\n",
+        "\n",
+        "license_keys = files.upload()\n",
+        "\n",
+        "with open(list(license_keys.keys())[0]) as f:\n",
+        "    license_keys = json.load(f)\n",
+        "\n",
+        "# Defining license key-value pairs as local variables\n",
+        "locals().update(license_keys)\n",
+        "\n",
+        "# Adding license key-value pairs to environment variables\n",
+        "os.environ.update(license_keys)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "kilg7TU4HPSY",
+        "outputId": "e6d01d48-a79d-48a4-e984-b365fe6bb919"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "\u001b[K     |████████████████████████████████| 212.4 MB 72 kB/s \n",
+            "\u001b[K     |████████████████████████████████| 130 kB 44.1 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 198 kB 48.1 MB/s \n",
+            "\u001b[?25h  Building wheel for pyspark (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "\u001b[K     |████████████████████████████████| 136 kB 5.0 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 95 kB 2.4 MB/s \n",
+            "\u001b[K     |████████████████████████████████| 66 kB 3.7 MB/s \n",
+            "\u001b[?25h"
+          ]
+        }
+      ],
+      "source": [
+        "# Installing pyspark and spark-nlp\n",
+        "! pip install --upgrade -q pyspark==3.1.2 spark-nlp==$PUBLIC_VERSION\n",
+        "\n",
+        "# Installing Spark NLP Healthcare\n",
+        "! pip install --upgrade -q spark-nlp-jsl==$JSL_VERSION  --extra-index-url https://pypi.johnsnowlabs.com/$SECRET\n",
+        "\n",
+        "# Installing Spark NLP Display Library for visualization\n",
+        "! pip install -q spark-nlp-display"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 271
+        },
+        "id": "_gzYc9fBVH8C",
+        "outputId": "c56ba1ed-60c7-4ac6-b19f-7e68ce2bb484"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Spark NLP Version : 3.3.2\n",
+            "Spark NLP_JSL Version : 3.3.2\n",
+            "Warning::Spark Session already created, some configs may not take.\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "            <div>\n",
+              "                <p><b>SparkSession - in-memory</b></p>\n",
+              "                \n",
+              "        <div>\n",
+              "            <p><b>SparkContext</b></p>\n",
+              "\n",
+              "            <p><a href=\"http://f5cc1c6f8d72:4040\">Spark UI</a></p>\n",
+              "\n",
+              "            <dl>\n",
+              "              <dt>Version</dt>\n",
+              "                <dd><code>v3.1.2</code></dd>\n",
+              "              <dt>Master</dt>\n",
+              "                <dd><code>local[*]</code></dd>\n",
+              "              <dt>AppName</dt>\n",
+              "                <dd><code>Spark NLP Licensed</code></dd>\n",
+              "            </dl>\n",
+              "        </div>\n",
+              "        \n",
+              "            </div>\n",
+              "        "
+            ],
+            "text/plain": [
+              "<pyspark.sql.session.SparkSession at 0x7f61a0752890>"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "import pandas as pd\n",
+        "import requests\n",
+        "import json\n",
+        "from zipfile import ZipFile\n",
+        "from io import BytesIO\n",
+        "import os\n",
+        "from pyspark.ml import Pipeline,PipelineModel\n",
+        "from pyspark.sql import SparkSession\n",
+        "from pyspark.sql import functions as F\n",
+        "\n",
+        "from sparknlp.annotator import *\n",
+        "from sparknlp_jsl.annotator import *\n",
+        "from sparknlp.base import *\n",
+        "import sparknlp_jsl\n",
+        "import sparknlp\n",
+        "\n",
+        "import warnings\n",
+        "warnings.filterwarnings('ignore')\n",
+        "\n",
+        "params = {\"spark.driver.memory\":\"16G\", \n",
+        "          \"spark.kryoserializer.buffer.max\":\"2000M\", \n",
+        "          \"spark.driver.maxResultSize\":\"2000M\"} \n",
+        "\n",
+        "print (\"Spark NLP Version :\", sparknlp.version())\n",
+        "print (\"Spark NLP_JSL Version :\", sparknlp_jsl.version())\n",
+        "\n",
+        "spark = sparknlp_jsl.start(license_keys['SECRET'],params=params)\n",
+        "\n",
+        "spark"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "sIijfVRHVH8G"
+      },
+      "source": [
+        "**Note: The base url for this demo is: https://annotationlab.johnsnowlabs.com - you can change this accordingly**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "k7RkDZKNbEsX"
+      },
+      "source": [
+        "**Provide you user credentials**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "QHcR4IBqa_tA"
+      },
+      "outputs": [],
+      "source": [
+        "username = 'user'\n",
+        "password = 'pass'\n",
+        "client_secret = \"secret\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Ql-Hs0yzVH8H"
+      },
+      "source": [
+        "**Helper Function to get cookies**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XGQqgAIRVH8I",
+        "outputId": "584ab7b6-b60c-4a8d-bb61-77aa688b2fff",
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "200\n"
+          ]
+        }
+      ],
+      "source": [
+        "def get_cookies(username, password):\n",
+        "    \n",
+        "    \n",
+        "    url = \"https://annotationlab.johnsnowlabs.com/openid-connect/token\"\n",
+        "    \n",
+        "    headers = {\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "        \"accept\": \"*/*\",\n",
+        "    }\n",
+        "    \n",
+        "    data = {\n",
+        "      \"username\": username,\n",
+        "      \"password\": password,\n",
+        "      \"client_id\": \"annotator\",\n",
+        "      \"client_secret\": client_secret\n",
+        "    }\n",
+        "    \n",
+        "    resp = requests.post(url, headers=headers, json=data)\n",
+        "    print (resp.status_code)\n",
+        "    auth_info = resp.json()\n",
+        "\n",
+        "    cookies = {\n",
+        "        'access_token': f\"Bearer {auth_info['access_token']}\",\n",
+        "        'refresh_token': auth_info['refresh_token']\n",
+        "    }\n",
+        "    return cookies\n",
+        "\n",
+        "cookies = get_cookies(username, password)\n",
+        "#cookies"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QkkJwmEqVH8I"
+      },
+      "source": [
+        "# Download sample data for uploading to Alab"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "YbMedxfWVH8J"
+      },
+      "outputs": [],
+      "source": [
+        "# Downloading sample datasets.\n",
+        "! wget -q https://raw.githubusercontent.com/JohnSnowLabs/spark-nlp-workshop/master/tutorials/Certification_Trainings/Healthcare/data/mt_samples.csv\n",
+        "    "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 224
+        },
+        "id": "1zZg2j0dVH8J",
+        "outputId": "0a106271-604e-4dd9-f5da-a5a626cb7891"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(50, 1)\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>text</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                                text\n",
+              "0  Sample Type / Medical Specialty:\\nHematology -...\n",
+              "1  Sample Type / Medical Specialty:\\nHematology -...\n",
+              "2  Sample Type / Medical Specialty:\\nHematology -...\n",
+              "3  Sample Type / Medical Specialty:\\nHematology -...\n",
+              "4  Sample Type / Medical Specialty:\\nHematology -..."
+            ]
+          },
+          "execution_count": 26,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "sample_data = pd.read_csv('mt_samples.csv')\n",
+        "print (sample_data.shape)\n",
+        "sample_data.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wSZVXEZAVH8K"
+      },
+      "source": [
+        "# 1. Pre-annotate, and upload to a project on Alab\n",
+        "\n",
+        "**Note: Your project configuration should be coherent with your pre-annotation pipeline**"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lXqhEvreVH8L"
+      },
+      "source": [
+        "**1.1 Pipeline for pre-annotation. You can change according to requirements.**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "YLnh_EgRVH8L",
+        "outputId": "ca7e64e4-38d9-4b07-96a6-5fa2799fc438"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "embeddings_clinical download started this may take some time.\n",
+            "Approximate size to download 1.6 GB\n",
+            "[OK!]\n",
+            "ner_jsl download started this may take some time.\n",
+            "Approximate size to download 14.5 MB\n",
+            "[OK!]\n",
+            "assertion_dl download started this may take some time.\n",
+            "Approximate size to download 1.3 MB\n",
+            "[OK!]\n"
+          ]
+        }
+      ],
+      "source": [
+        "document = DocumentAssembler()\\\n",
+        "    .setInputCol(\"text\")\\\n",
+        "    .setOutputCol(\"document\")\n",
+        "\n",
+        "sentence = SentenceDetector()\\\n",
+        "    .setInputCols(['document'])\\\n",
+        "    .setOutputCol('sentence')\\\n",
+        "    .setCustomBounds(['\\n'])\n",
+        "\n",
+        "tokenizer = Tokenizer() \\\n",
+        "    .setInputCols([\"sentence\"]) \\\n",
+        "    .setOutputCol(\"token\")\\\n",
+        "    .setSplitChars(['\\[','\\]'])\\\n",
+        "    .setContextChars([\".\", \",\", \";\", \":\", \"!\", \"?\", \"*\", \"-\", \"(\", \")\", \"\\\"\", \"'\",\"+\",\"%\",\"-\"])\n",
+        "\n",
+        "word_embeddings = WordEmbeddingsModel().pretrained('embeddings_clinical', 'en', 'clinical/models')\\\n",
+        "    .setInputCols([\"sentence\", 'token']) \\\n",
+        "    .setOutputCol(\"embeddings\")\\\n",
+        "\n",
+        "ner_model = MedicalNerModel.pretrained('ner_jsl', 'en', 'clinical/models')\\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"embeddings\"])\\\n",
+        "    .setOutputCol(\"ner\")\n",
+        "\n",
+        "converter = NerConverter()\\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"ner\"])\\\n",
+        "    .setOutputCol(\"ner_chunk\")\n",
+        "\n",
+        "assertion_model = AssertionDLModel().pretrained('assertion_dl', 'en', 'clinical/models')\\\n",
+        "    .setInputCols([\"sentence\", \"ner_chunk\", 'embeddings'])\\\n",
+        "    .setOutputCol(\"assertion_res\")\n",
+        "\n",
+        "ner_pipeline = Pipeline(\n",
+        "    stages = [\n",
+        "        document,\n",
+        "        sentence,\n",
+        "        tokenizer,\n",
+        "        word_embeddings,\n",
+        "        ner_model,\n",
+        "        converter,\n",
+        "        assertion_model\n",
+        "    ])\n",
+        "\n",
+        "empty_data = spark.createDataFrame([['']]).toDF(\"text\")\n",
+        "pipeline_model = ner_pipeline.fit(empty_data)\n",
+        "lmodel = LightPipeline(pipeline_model)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zreCQgDFVH8M"
+      },
+      "source": [
+        "**1.2 Get Pre-Annotations using the pipeline above and convert to required format**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "R_GQtfPJVH8N",
+        "outputId": "b219cd72-52ae-499b-afb3-c2b8409281a4"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "50  documents will be preannotated ...\n",
+            "created spark dataframe ... transforming started\n",
+            "pandas conversion started\n"
+          ]
+        }
+      ],
+      "source": [
+        "from pyspark.sql.types import *\n",
+        "\n",
+        "def get_preannotations_from_NER (list_of_files, ner_prediction_model):\n",
+        "    \n",
+        "    print (len(list_of_files), \" documents will be preannotated ...\")\n",
+        "    \n",
+        "    file_text_tuples = []\n",
+        "    for index, file_text in enumerate(list_of_files):\n",
+        "        ## \n",
+        "        file_text_tuples.append((index, # id of the file\n",
+        "                                 'demo_mt_samples_{}'.format(index), # this is the title that appears on the UI\n",
+        "                                 file_text # text of the file\n",
+        "                                ))\n",
+        "        \n",
+        "    # Define schema\n",
+        "    schema = StructType([\n",
+        "        StructField(\"task_id\", StringType(), True),\n",
+        "        StructField(\"title\", StringType(), True),\n",
+        "        StructField(\"text\", StringType(), True)\n",
+        "    ])\n",
+        "\n",
+        "    # Create dataframe\n",
+        "    \n",
+        "    spark_df = spark.createDataFrame(file_text_tuples, schema)\n",
+        "    \n",
+        "    print (\"created spark dataframe ... transforming started\")\n",
+        "        \n",
+        "    pred_df = ner_prediction_model.transform(spark_df)\n",
+        "    \n",
+        "    print (\"pandas conversion started\")\n",
+        "    \n",
+        "    view_df = pred_df.select(\"task_id\",\n",
+        "                             'title', \n",
+        "                             \"text\",\n",
+        "                             \"ner_chunk\", ## you can change this to any column name (the final chunk column in your pp)\n",
+        "                             \"assertion_res\" # - if you want assertion annotations as well\n",
+        "                            ).toPandas()\n",
+        "    \n",
+        "        \n",
+        "    view_df['task_id']=view_df['task_id'].astype(int)\n",
+        "    \n",
+        "    return view_df\n",
+        "\n",
+        "preds_df = get_preannotations_from_NER(sample_data['text'].values, pipeline_model)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vC0tuOo6VH8N"
+      },
+      "source": [
+        "**1.3 Prepare the JSON to upload to Alab**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ZK3OHDtIVH8O",
+        "outputId": "1e16df7a-9759-4672-aada-f5d2b7a19292"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Annotations payload is ready\n",
+            "Annotated Documents: 50\n"
+          ]
+        }
+      ],
+      "source": [
+        "import random as rand\n",
+        "import datetime\n",
+        "\n",
+        "def generate_hash(length=10):    \n",
+        "    nums = list(range(48,58))\n",
+        "    uppers = list(range(65,91))\n",
+        "    lowers = list(range(97,123))\n",
+        "    all_chars = nums+uppers+lowers\n",
+        "    return \"\".join([chr(all_chars[rand.randint(0, len(all_chars)-1)]) for x in range(length)])\n",
+        "\n",
+        "def create_import_json (username, pandas_pred_df, project_id):\n",
+        "    \n",
+        "    def build_label(chunk, start, end, label):\n",
+        "        \n",
+        "        label_json = {\n",
+        "                \"from_name\": \"label\",\n",
+        "                \"id\": generate_hash(),\n",
+        "                \"source\": \"$text\",\n",
+        "                \"to_name\": \"text\",\n",
+        "                \"type\": \"labels\",\n",
+        "                \"value\": {\n",
+        "                  \"end\": end,\n",
+        "                  \"labels\": [label],\n",
+        "                  \"start\": start,\n",
+        "                  \"text\": chunk\n",
+        "                }\n",
+        "              }\n",
+        "        return label_json\n",
+        "\n",
+        "    import_json = []\n",
+        "\n",
+        "    for i,row in pandas_pred_df.iterrows():\n",
+        "       \n",
+        "        results_jsons = [] \n",
+        "        \n",
+        "        assertion_mapper = {}\n",
+        "        for x in row[\"ner_chunk\"]: # assign proper column name\n",
+        "            if not pd.isna(x):\n",
+        "                results_jsons.append(build_label(x.result, x.begin, x.end+1, x.metadata[\"entity\"]))\n",
+        "                assertion_mapper[x.begin] = x.result\n",
+        "                \n",
+        "        # comment out this loop if assertion is not required\n",
+        "        for x in row[\"assertion_res\"]:\n",
+        "            if not pd.isna(x):\n",
+        "                results_jsons.append(build_label(assertion_mapper[x.begin], x.begin, x.end+1, x.result))\n",
+        "                \n",
+        "             \n",
+        "        import_json.append({\"predictions\": [{\n",
+        "            'created_username': username,\n",
+        "                \"result\":results_jsons\n",
+        "            }],\n",
+        "            \"data\":{\n",
+        "                \"text\":row[\"text\"],\n",
+        "                \"title\":row['title']\n",
+        "            },\n",
+        "                            'id':row['task_id']\n",
+        "                           })\n",
+        "    \n",
+        "    print (\"Annotations payload is ready\")\n",
+        "    \n",
+        "    return import_json\n",
+        "\n",
+        "annotation_json = create_import_json('ner_jsl', preds_df, 'demo_100')\n",
+        "\n",
+        "print ('Annotated Documents:' , len(annotation_json))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "8RcutO2iVH8O"
+      },
+      "source": [
+        "**1.4 Upload pre-annotations to Alab**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 105
+        },
+        "id": "pfdZaAvHVH8O",
+        "outputId": "40a96d64-49ec-4a1a-b8b7-280c2c385cf9"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "https://annotationlab.johnsnowlabs.com/api/projects/demo_100/import\n",
+            "200\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "'{\"completion_count\":0,\"duration\":6.411985635757446,\"failed_count\":0,\"ignored_count\":0,\"prediction_count\":50,\"task_count\":50,\"task_ids\":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49],\"task_title_warning\":0,\"updated_count\":0}\\n'"
+            ]
+          },
+          "execution_count": 30,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "project_name = 'demo_100'\n",
+        "url = \"https://annotationlab.johnsnowlabs.com/api/projects/{}/import\".format(project_name)\n",
+        "print (url)\n",
+        "\n",
+        "headers = {\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "        \"accept\": \"*/*\"\n",
+        "    }\n",
+        "\n",
+        "cookies = get_cookies(username, password)\n",
+        "\n",
+        "resp = requests.post(url, headers = headers, cookies = cookies, json = annotation_json)\n",
+        "\n",
+        "resp.status_code\n",
+        "resp.text"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GNRDzyhmVH8P"
+      },
+      "source": [
+        "# 2. Download / Export a project as json from Alab"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-NCcKmLqhEAa"
+      },
+      "source": [
+        "**2.1 Export project from Alab**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mnNVex2FVH8P",
+        "outputId": "8d5c5ce3-0923-432b-d768-22062d6f84de",
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "https://annotationlab.johnsnowlabs.com/api/projects/demo_100/export?format=JSON\n",
+            "200\n",
+            "Total tasks in the project with completions: 4\n"
+          ]
+        }
+      ],
+      "source": [
+        "project_name = 'demo_100'\n",
+        "url = \"https://annotationlab.johnsnowlabs.com/api/projects/{}/export?format=JSON\".format(project_name)\n",
+        "print (url)\n",
+        "\n",
+        "headers = {\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "        \"accept\": \"*/*\"\n",
+        "    }\n",
+        "\n",
+        "cookies = get_cookies(username, password)\n",
+        "\n",
+        "resp = requests.post(url, headers = headers, cookies = cookies)\n",
+        "\n",
+        "zipfile = ZipFile(BytesIO(resp.content))\n",
+        "with zipfile.open(zipfile.namelist()[0]) as f:  \n",
+        "    data = f.read()  \n",
+        "project_json = json.loads(data)  \n",
+        "\n",
+        "print ('Total tasks in the project with completions:', len(project_json))\n",
+        "\n",
+        "with open('project_export.json', 'w') as f_:\n",
+        "    f_.write(json.dumps(project_json, indent=4))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "93UnENybjKH7"
+      },
+      "source": [
+        "**2.1 Parse the project json and generate conll file**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from sparknlp.annotator import *\n",
+        "from sparknlp_jsl.annotator import *\n",
+        "from sparknlp.base import *\n",
+        "from pyspark.ml import Pipeline, PipelineModel\n",
+        "\n",
+        "def get_nlp_pipeline():\n",
+        "\n",
+        "    documentAssembler = DocumentAssembler()\\\n",
+        "      .setInputCol(\"text\")\\\n",
+        "      .setOutputCol(\"document\")\n",
+        "\n",
+        "    sentenceDetector = SentenceDetectorDLModel.pretrained(\"sentence_detector_dl_healthcare\",\"en\",\"clinical/models\")\\\n",
+        "      .setInputCols([\"document\"])\\\n",
+        "      .setOutputCol(\"sentence\")\n",
+        "    \n",
+        "    pattern = \"\\\\s+|(?=[-.:;*+,$&%\\\\[\\\\]\\\\(\\\\)\\\\/])|(?<=[-.:;*+,$&%\\\\[\\\\]\\\\(\\\\)\\\\/])\"\n",
+        "    \n",
+        "    regex_tokenizer = RegexTokenizer() \\\n",
+        "        .setInputCols([\"sentence\"]) \\\n",
+        "        .setOutputCol(\"token\")\\\n",
+        "        .setPositionalMask(True)\\\n",
+        "        .setPattern(pattern)\n",
+        "        \n",
+        "    pos = PerceptronModel.pretrained(\"pos_clinical\",\"en\",\"clinical/models\")\\\n",
+        "        .setInputCols([\"sentence\", \"token\"]) \\\n",
+        "        .setOutputCol(\"pos\")\n",
+        "\n",
+        "    pipeline = Pipeline(\n",
+        "        stages = [\n",
+        "            documentAssembler,\n",
+        "            sentenceDetector,\n",
+        "            regex_tokenizer,\n",
+        "            pos]\n",
+        "    )\n",
+        "\n",
+        "    empty_data = spark.createDataFrame([[\"\"]]).toDF(\"text\")\n",
+        "\n",
+        "    pipelineFit = pipeline.fit(empty_data)\n",
+        "\n",
+        "    lp_pipeline = LightPipeline(pipelineFit)\n",
+        "    \n",
+        "    print (\"Spark NLP lightpipeline is created\")\n",
+        "    \n",
+        "    return lp_pipeline\n",
+        "\n",
+        "lp_pipeline =  get_nlp_pipeline()\n",
+        "\n",
+        "def get_token_pipeline():\n",
+        "\n",
+        "    documentAssembler = DocumentAssembler()\\\n",
+        "      .setInputCol(\"text\")\\\n",
+        "      .setOutputCol(\"sentence\")\n",
+        "    \n",
+        "    pattern = \"\\\\s+|(?=[-.:;*+,$&%\\\\[\\\\]\\\\(\\\\)\\\\/])|(?<=[-.:;*+,$&%\\\\[\\\\]\\\\(\\\\)\\\\/])\"\n",
+        "    \n",
+        "    regex_tokenizer = RegexTokenizer() \\\n",
+        "        .setInputCols([\"sentence\"]) \\\n",
+        "        .setOutputCol(\"token\")\\\n",
+        "        .setPositionalMask(True)\\\n",
+        "        .setPattern(pattern)\n",
+        "\n",
+        "    pipeline = Pipeline(\n",
+        "        stages = [\n",
+        "            documentAssembler,\n",
+        "            regex_tokenizer]\n",
+        "    )\n",
+        "\n",
+        "    empty_data = spark.createDataFrame([[\"\"]]).toDF(\"text\")\n",
+        "\n",
+        "    pipelineFit = pipeline.fit(empty_data)\n",
+        "\n",
+        "    lp_pipeline = LightPipeline(pipelineFit)\n",
+        "    \n",
+        "    print(\"Spark NLP lightpipeline is created\")\n",
+        "    \n",
+        "    return lp_pipeline\n",
+        "\n",
+        "token_lp_pipeline =  get_token_pipeline()"
+      ],
+      "metadata": {
+        "id": "W6jw9MRtrMe7"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def get_conll_manual(lp_pipeline, output, excludedDocs=[''], \n",
+        "                     excluded=['present', 'absent', 'possbile', 'hypothetical', 'conditional', 'associated_with_someone_else'], # set all assertions here\n",
+        "                     included_phrase=''):\n",
+        "    \n",
+        "    conll_lines=[]\n",
+        "\n",
+        "    try:\n",
+        "        new_content = output['data']['text']\n",
+        "    except:\n",
+        "        new_content =  output['data']['longText']\n",
+        "    \n",
+        "    try:\n",
+        "        title = output['data']['title']\n",
+        "    except:\n",
+        "        title = \"task_id\" + str(output['id'])\n",
+        "    print(title)\n",
+        "    n = lp_pipeline.fullAnnotate(new_content)\n",
+        "\n",
+        "    sent_tuples = {str(x.metadata['sentence']): (x.begin, x.end) for x in n[0]['sentence']}\n",
+        "    parsed = [(int(x.metadata['sentence']), x.result, x.begin, x.end, y.result, sent_tuples[x.metadata['sentence']][0]) for x,y in zip(n[0][\"token\"],n[0][\"pos\"])]\n",
+        "\n",
+        "    ents = []\n",
+        "    \n",
+        "    if len(output['completions'])!=0 and title.strip() not in excludedDocs:\n",
+        "\n",
+        "        ann_results = output['completions'][-1]['result']\n",
+        "\n",
+        "        for d in ann_results: \n",
+        "            #and included_phrase in d['value']['labels'][0] \n",
+        "            if d['type']=='labels' and \\\n",
+        "            d['value']['labels'][0].replace(' ','') not in excluded:                \n",
+        "                \n",
+        "                temp_text = d['value']['text']\n",
+        "                start=d['value']['start']\n",
+        "                end=d['value']['end']\n",
+        "\n",
+        "                if len(temp_text)!=len(temp_text.rstrip()):\n",
+        "                    end = end-(len(temp_text)-len(temp_text.rstrip()))\n",
+        "                    temp_text = temp_text.rstrip()\n",
+        "\n",
+        "                if len(temp_text)!=len(temp_text.lstrip()):\n",
+        "                    start = start+(len(temp_text)-len(temp_text.lstrip())) \n",
+        "                    temp_text = temp_text.lstrip()\n",
+        "\n",
+        "                ents.append((temp_text, d['value']['labels'][0].replace(' ',''), start, end))\n",
+        "\n",
+        "        text_df = pd.DataFrame(ents, columns=['chunk','label','start','end']) \n",
+        "        \n",
+        "        text_df['label'] = text_df['label'].apply(lambda x: x.replace(' ',''))   \n",
+        "        \n",
+        "        text_df.sort_values(by=['start', 'end'], inplace=True)\n",
+        "        text_df.reset_index(drop=True, inplace=True)\n",
+        "        \n",
+        "        df = text_df.copy()\n",
+        "        \n",
+        "        tag_dict = {}\n",
+        "        \n",
+        "\n",
+        "        for i,row in df.iterrows():\n",
+        "                               \n",
+        "            base_ix= row[\"start\"]\n",
+        "            \n",
+        "            chunk_tokens = token_lp_pipeline.fullAnnotate(row['chunk'])[0]['token']\n",
+        "\n",
+        "            for i, token in enumerate(chunk_tokens):\n",
+        "                if i == 0:\n",
+        "                    iob = 'B-'\n",
+        "                else:\n",
+        "                    iob = 'I-'\n",
+        "                tag_dict[(base_ix+token.begin, token.result)] = iob + row['label'].replace(' ','')  \n",
+        "                \n",
+        "        s=0\n",
+        "        for i, p in enumerate(parsed):\n",
+        "            if p[0]!=s:\n",
+        "                conll_lines.append(\"\\n\")\n",
+        "                s+=1\n",
+        "            conll_lines.append(\"{} {} {} {}\\n\".format(p[1], p[4], p[4], tag_dict.get((p[2]+p[-1],p[1]),\"O\")))\n",
+        "\n",
+        "        conll_lines.append(\"\\n\")\n",
+        "\n",
+        "        return conll_lines\n",
+        "    \n",
+        "    else:\n",
+        "       \n",
+        "        return ''\n",
+        "\n",
+        "\n",
+        "def get_conll_from_json_manual(pid, bulk_json_file_path):\n",
+        "    \n",
+        "    with open(bulk_json_file_path, 'r') as json_file:\n",
+        "        \n",
+        "        json_outputs = json.load(json_file)\n",
+        "    \n",
+        "    bulk_conll_lines = [\"-DOCSTART- -X- -X- O\\n\\n\"]\n",
+        "\n",
+        "    print (len(json_outputs))\n",
+        "    \n",
+        "    for o, output in enumerate(json_outputs):\n",
+        "\n",
+        "        in_conll_lines = get_conll_manual(lp_pipeline, output) \n",
+        "        \n",
+        "        bulk_conll_lines.extend(in_conll_lines)\n",
+        "        \n",
+        "        print (o)        \n",
+        "        \n",
+        "    try:\n",
+        "        os.mkdir('exported_conlls')\n",
+        "    except:\n",
+        "        pass\n",
+        "\n",
+        "    with open('exported_conlls/project_{}.conll'.format(pid), 'w', encoding='utf-8') as f:\n",
+        "        for i in bulk_conll_lines:\n",
+        "            f.write(i)\n",
+        "\n",
+        "    print ('exported_conlls/project_{}.conll'.format(pid))\n",
+        "    \n",
+        "    return bulk_conll_lines"
+      ],
+      "metadata": {
+        "id": "V0E1ByEWra-F"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "get_conll_from_json_manual('demo_100','./project_export.json')"
+      ],
+      "metadata": {
+        "id": "Dh0AnpH4syZb"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eWgJvL7GjbAH"
+      },
+      "source": [
+        "**2.2 Generate Data for Training Assertion Model**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "i8chf7-dgGFl"
+      },
+      "outputs": [],
+      "source": [
+        "from sparknlp_jsl.training import *\n",
+        "from pyspark.sql import functions as F\n",
+        "\n",
+        "json_path = './project_export.json'\n",
+        "\n",
+        "rdr = AnnotationToolJsonReader(assertion_labels = ['present', 'absent', 'possbile', 'hypothetical', 'conditional', 'associated_with_someone_else'])\n",
+        "\n",
+        "df_anns = rdr.readDataset(spark, json_path).withColumn(\"json\",F.lit(json_path))\n",
+        "\n",
+        "df_anns = NerConverter().setInputCols(['sentence', 'token', 'ner_label']).setOutputCol('ner_chunks').transform(df_anns)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 577
+        },
+        "id": "43eUjt5akJ-0",
+        "outputId": "0dff4d49-c2eb-4168-c741-32e2a73b501a"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(4, 14)\n",
+            "4\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>title</th>\n",
+              "      <th>task_id</th>\n",
+              "      <th>text</th>\n",
+              "      <th>completion_id</th>\n",
+              "      <th>tool_chunk</th>\n",
+              "      <th>assertion_label</th>\n",
+              "      <th>relations</th>\n",
+              "      <th>document</th>\n",
+              "      <th>sentence</th>\n",
+              "      <th>token</th>\n",
+              "      <th>ner_label</th>\n",
+              "      <th>ner_chunk</th>\n",
+              "      <th>json</th>\n",
+              "      <th>ner_chunks</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>demo_mt_samples_46</td>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>46001</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
+              "      <td>[(assertion, 33, 42, present, {'chunk_id': 'IY...</td>\n",
+              "      <td>[]</td>\n",
+              "      <td>[(document, 0, 10211, Sample Type / Medical Sp...</td>\n",
+              "      <td>[(document, 0, 189, Sample Type / Medical Spec...</td>\n",
+              "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
+              "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "      <td>./project_export.json</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>demo_mt_samples_47</td>\n",
+              "      <td>47</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>47001</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
+              "      <td>[(assertion, 33, 42, present, {'chunk_id': '8P...</td>\n",
+              "      <td>[]</td>\n",
+              "      <td>[(document, 0, 3491, Sample Type / Medical Spe...</td>\n",
+              "      <td>[(document, 0, 144, Sample Type / Medical Spec...</td>\n",
+              "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
+              "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "      <td>./project_export.json</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>demo_mt_samples_48</td>\n",
+              "      <td>48</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>48001</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
+              "      <td>[(assertion, 33, 42, present, {'chunk_id': '3b...</td>\n",
+              "      <td>[]</td>\n",
+              "      <td>[(document, 0, 2863, Sample Type / Medical Spe...</td>\n",
+              "      <td>[(document, 0, 126, Sample Type / Medical Spec...</td>\n",
+              "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
+              "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "      <td>./project_export.json</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>demo_mt_samples_49</td>\n",
+              "      <td>49</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>49001</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'entity': 'Clini...</td>\n",
+              "      <td>[(assertion, 33, 42, present, {'chunk_id': 'aZ...</td>\n",
+              "      <td>[]</td>\n",
+              "      <td>[(document, 0, 5889, Sample Type / Medical Spe...</td>\n",
+              "      <td>[(document, 0, 319, Sample Type / Medical Spec...</td>\n",
+              "      <td>[(token, 0, 5, Sample, {'sentence': '0'}, []),...</td>\n",
+              "      <td>[(named_entity, 0, 5, O, {'sentence': '0', 'wo...</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "      <td>./project_export.json</td>\n",
+              "      <td>[(chunk, 33, 42, Hematology, {'sentence': '0',...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                title  ...                                         ner_chunks\n",
+              "1  demo_mt_samples_46  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
+              "2  demo_mt_samples_47  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
+              "3  demo_mt_samples_48  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
+              "0  demo_mt_samples_49  ...  [(chunk, 33, 42, Hematology, {'sentence': '0',...\n",
+              "\n",
+              "[4 rows x 14 columns]"
+            ]
+          },
+          "execution_count": 44,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "rel_pds = df_anns.toPandas()\n",
+        "print (rel_pds.shape)\n",
+        "print (rel_pds['task_id'].nunique())\n",
+        "rel_pds = rel_pds.sort_values('completion_id').drop_duplicates('task_id', keep='last')\n",
+        "rel_pds.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "e97vwcDYjZuH",
+        "outputId": "ec70673c-f38a-4d61-8ddd-afc366985053"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "46\n",
+            "47\n",
+            "48\n",
+            "49\n",
+            "present                         634\n",
+            "absent                          300\n",
+            "hypothetical                     48\n",
+            "associated_with_someone_else     36\n",
+            "conditional                      11\n",
+            "Name: assertion_label, dtype: int64\n",
+            "(1029, 12)\n"
+          ]
+        }
+      ],
+      "source": [
+        "\n",
+        "all_tasks_assertions = []\n",
+        "all_tasks_relations = []\n",
+        "for index, group in rel_pds.groupby('task_id'):\n",
+        "    \n",
+        "    print (index)\n",
+        "    \n",
+        "    ann_chunks = pd.DataFrame( [{'chunk_id': i.metadata['chunk_id'], 'chunk': i.result, 'begin': int(i.begin), 'end': i.end, 'entity': i.metadata['entity']} for i in group['tool_chunk'].explode() ] )\n",
+        "        \n",
+        "    ner_chunks = pd.DataFrame( [{'chunk_num': ii, 'chunk': i.result, 'begin': int(i.begin), 'end': i.end, 'sentence_id': int(i.metadata['sentence'])} for ii, i in enumerate(group['ner_chunks'].explode()) ] )\n",
+        "    \n",
+        "    with_sent = pd.merge(ann_chunks[['chunk_id', 'begin', 'entity']], ner_chunks, on=['begin'], how='inner')\n",
+        "    \n",
+        "    sentences_df = pd.DataFrame( [{'sentence_id': int(i.metadata['sentence']), 'sentence': i.result, 'sent_begin': int(i.begin), 'sent_end': int(i.end)} for i in group['sentence'].explode() ] )\n",
+        "    \n",
+        "    with_sent = pd.merge(with_sent, sentences_df, on=['sentence_id'], how='inner')\n",
+        "\n",
+        "    assertion_chunks = pd.DataFrame( [{'assertion_label': i.result, 'begin': int(i.begin) } for i in group['assertion_label'].explode() ] )\n",
+        "    \n",
+        "    assertion_chunks = pd.merge(assertion_chunks, with_sent, on=['begin'], how='inner')\n",
+        "    \n",
+        "    assertion_chunks['task_id'] = index\n",
+        "    all_tasks_assertions.append(assertion_chunks)\n",
+        "        \n",
+        "all_tasks_assertions = pd.concat(all_tasks_assertions, axis=0)\n",
+        "print (all_tasks_assertions['assertion_label'].value_counts())\n",
+        "\n",
+        "all_tasks_assertions['begin'] = all_tasks_assertions['begin'] - all_tasks_assertions['sent_begin']\n",
+        "all_tasks_assertions['end'] = all_tasks_assertions['end'] - all_tasks_assertions['sent_begin']\n",
+        "\n",
+        "print (all_tasks_assertions.shape)               \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "HJJgszFHkQXv",
+        "outputId": "c96ec30d-9693-488d-9ef4-7fdff436d8d6"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(1029, 14)\n",
+            "(1029, 14)\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>task_id</th>\n",
+              "      <th>sentence</th>\n",
+              "      <th>tkn_start</th>\n",
+              "      <th>tkn_end</th>\n",
+              "      <th>chunk</th>\n",
+              "      <th>entity</th>\n",
+              "      <th>assertion_label</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>4</td>\n",
+              "      <td>4</td>\n",
+              "      <td>Hematology</td>\n",
+              "      <td>Clinical_Dept</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>6</td>\n",
+              "      <td>Oncology</td>\n",
+              "      <td>Clinical_Dept</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>7</td>\n",
+              "      <td>10</td>\n",
+              "      <td>Non-Small Cell Lung Cancer</td>\n",
+              "      <td>Oncological</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>12</td>\n",
+              "      <td>12</td>\n",
+              "      <td>Description:</td>\n",
+              "      <td>Section_Header</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>15</td>\n",
+              "      <td>18</td>\n",
+              "      <td>non-small cell lung cancer</td>\n",
+              "      <td>Oncological</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>19</td>\n",
+              "      <td>20</td>\n",
+              "      <td>stage IV</td>\n",
+              "      <td>Modifier</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Sample Type / Medical Specialty:\\nHematology -...</td>\n",
+              "      <td>21</td>\n",
+              "      <td>22</td>\n",
+              "      <td>metastatic disease</td>\n",
+              "      <td>Oncological</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>46</td>\n",
+              "      <td>At this point, he and his wife ask about wheth...</td>\n",
+              "      <td>3</td>\n",
+              "      <td>3</td>\n",
+              "      <td>he</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>46</td>\n",
+              "      <td>At this point, he and his wife ask about wheth...</td>\n",
+              "      <td>5</td>\n",
+              "      <td>5</td>\n",
+              "      <td>his</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>46</td>\n",
+              "      <td>At this point, he and his wife ask about wheth...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>6</td>\n",
+              "      <td>wife</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>46</td>\n",
+              "      <td>(Medical Transcription Sample Report)\\nREASON ...</td>\n",
+              "      <td>3</td>\n",
+              "      <td>5</td>\n",
+              "      <td>REASON FOR CONSULTATION:</td>\n",
+              "      <td>Section_Header</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>11</th>\n",
+              "      <td>46</td>\n",
+              "      <td>(Medical Transcription Sample Report)\\nREASON ...</td>\n",
+              "      <td>8</td>\n",
+              "      <td>11</td>\n",
+              "      <td>non-small cell lung cancer</td>\n",
+              "      <td>Oncological</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>12</th>\n",
+              "      <td>46</td>\n",
+              "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>3</td>\n",
+              "      <td>HISTORY OF PRESENT ILLNESS:</td>\n",
+              "      <td>Section_Header</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>13</th>\n",
+              "      <td>46</td>\n",
+              "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
+              "      <td>8</td>\n",
+              "      <td>8</td>\n",
+              "      <td>47-year-old</td>\n",
+              "      <td>Age</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>14</th>\n",
+              "      <td>46</td>\n",
+              "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
+              "      <td>9</td>\n",
+              "      <td>9</td>\n",
+              "      <td>gentleman</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>15</th>\n",
+              "      <td>46</td>\n",
+              "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
+              "      <td>22</td>\n",
+              "      <td>22</td>\n",
+              "      <td>new</td>\n",
+              "      <td>Modifier</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>16</th>\n",
+              "      <td>46</td>\n",
+              "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
+              "      <td>27</td>\n",
+              "      <td>28</td>\n",
+              "      <td>stage IV</td>\n",
+              "      <td>Modifier</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>17</th>\n",
+              "      <td>46</td>\n",
+              "      <td>HISTORY OF PRESENT ILLNESS:\\nABCD is a very ni...</td>\n",
+              "      <td>29</td>\n",
+              "      <td>30</td>\n",
+              "      <td>metastatic disease</td>\n",
+              "      <td>Oncological</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>18</th>\n",
+              "      <td>46</td>\n",
+              "      <td>ABCD and his wife state that his history goes ...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>2</td>\n",
+              "      <td>his</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>19</th>\n",
+              "      <td>46</td>\n",
+              "      <td>ABCD and his wife state that his history goes ...</td>\n",
+              "      <td>3</td>\n",
+              "      <td>3</td>\n",
+              "      <td>wife</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>20</th>\n",
+              "      <td>46</td>\n",
+              "      <td>ABCD and his wife state that his history goes ...</td>\n",
+              "      <td>6</td>\n",
+              "      <td>6</td>\n",
+              "      <td>his</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>21</th>\n",
+              "      <td>46</td>\n",
+              "      <td>ABCD and his wife state that his history goes ...</td>\n",
+              "      <td>12</td>\n",
+              "      <td>14</td>\n",
+              "      <td>2-2-1/2 weeks ago</td>\n",
+              "      <td>RelativeDate</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>22</th>\n",
+              "      <td>46</td>\n",
+              "      <td>ABCD and his wife state that his history goes ...</td>\n",
+              "      <td>16</td>\n",
+              "      <td>16</td>\n",
+              "      <td>he</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>23</th>\n",
+              "      <td>46</td>\n",
+              "      <td>ABCD and his wife state that his history goes ...</td>\n",
+              "      <td>19</td>\n",
+              "      <td>19</td>\n",
+              "      <td>left-sided</td>\n",
+              "      <td>Direction</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>24</th>\n",
+              "      <td>46</td>\n",
+              "      <td>ABCD and his wife state that his history goes ...</td>\n",
+              "      <td>20</td>\n",
+              "      <td>21</td>\n",
+              "      <td>flank pain</td>\n",
+              "      <td>Symptom</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>25</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Initially, he did not think much of this and t...</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>he</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>26</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Initially, he did not think much of this and t...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>14</td>\n",
+              "      <td>did not think much of this and tried to go abo...</td>\n",
+              "      <td>Symptom</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>27</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Initially, he did not think much of this and t...</td>\n",
+              "      <td>20</td>\n",
+              "      <td>20</td>\n",
+              "      <td>pain</td>\n",
+              "      <td>Symptom</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>28</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Initially, he did not think much of this and t...</td>\n",
+              "      <td>21</td>\n",
+              "      <td>22</td>\n",
+              "      <td>gradually worsened</td>\n",
+              "      <td>Modifier</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>29</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Eventually this prompted him to present to the...</td>\n",
+              "      <td>3</td>\n",
+              "      <td>3</td>\n",
+              "      <td>him</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>30</th>\n",
+              "      <td>46</td>\n",
+              "      <td>Eventually this prompted him to present to the...</td>\n",
+              "      <td>8</td>\n",
+              "      <td>9</td>\n",
+              "      <td>emergency room</td>\n",
+              "      <td>Clinical_Dept</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>31</th>\n",
+              "      <td>46</td>\n",
+              "      <td>A CT scan was done there, and he was found to ...</td>\n",
+              "      <td>1</td>\n",
+              "      <td>2</td>\n",
+              "      <td>CT scan</td>\n",
+              "      <td>Test</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>32</th>\n",
+              "      <td>46</td>\n",
+              "      <td>A CT scan was done there, and he was found to ...</td>\n",
+              "      <td>7</td>\n",
+              "      <td>7</td>\n",
+              "      <td>he</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>33</th>\n",
+              "      <td>46</td>\n",
+              "      <td>A CT scan was done there, and he was found to ...</td>\n",
+              "      <td>13</td>\n",
+              "      <td>13</td>\n",
+              "      <td>large</td>\n",
+              "      <td>Modifier</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>34</th>\n",
+              "      <td>46</td>\n",
+              "      <td>A CT scan was done there, and he was found to ...</td>\n",
+              "      <td>14</td>\n",
+              "      <td>14</td>\n",
+              "      <td>left</td>\n",
+              "      <td>Direction</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>35</th>\n",
+              "      <td>46</td>\n",
+              "      <td>A CT scan was done there, and he was found to ...</td>\n",
+              "      <td>15</td>\n",
+              "      <td>16</td>\n",
+              "      <td>adrenal mass</td>\n",
+              "      <td>Symptom</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>36</th>\n",
+              "      <td>46</td>\n",
+              "      <td>At that point, he was transferred to XYZ Hospi...</td>\n",
+              "      <td>3</td>\n",
+              "      <td>3</td>\n",
+              "      <td>he</td>\n",
+              "      <td>Gender</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>37</th>\n",
+              "      <td>46</td>\n",
+              "      <td>At that point, he was transferred to XYZ Hospi...</td>\n",
+              "      <td>7</td>\n",
+              "      <td>8</td>\n",
+              "      <td>XYZ Hospital</td>\n",
+              "      <td>Clinical_Dept</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>38</th>\n",
+              "      <td>46</td>\n",
+              "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>admission</td>\n",
+              "      <td>Admission_Discharge</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>39</th>\n",
+              "      <td>46</td>\n",
+              "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
+              "      <td>3</td>\n",
+              "      <td>3</td>\n",
+              "      <td>12/19/08</td>\n",
+              "      <td>Date</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>40</th>\n",
+              "      <td>46</td>\n",
+              "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
+              "      <td>5</td>\n",
+              "      <td>6</td>\n",
+              "      <td>CT scan</td>\n",
+              "      <td>Test</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>41</th>\n",
+              "      <td>46</td>\n",
+              "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
+              "      <td>9</td>\n",
+              "      <td>9</td>\n",
+              "      <td>chest</td>\n",
+              "      <td>External_body_part_or_region</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>42</th>\n",
+              "      <td>46</td>\n",
+              "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
+              "      <td>10</td>\n",
+              "      <td>10</td>\n",
+              "      <td>abdomen</td>\n",
+              "      <td>External_body_part_or_region</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>43</th>\n",
+              "      <td>46</td>\n",
+              "      <td>On admission on 12/19/08, a CT scan of the che...</td>\n",
+              "      <td>12</td>\n",
+              "      <td>12</td>\n",
+              "      <td>pelvis</td>\n",
+              "      <td>Internal_organ_or_component</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>44</th>\n",
+              "      <td>46</td>\n",
+              "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
+              "      <td>1</td>\n",
+              "      <td>5</td>\n",
+              "      <td>CT scan of the chest</td>\n",
+              "      <td>Test</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>45</th>\n",
+              "      <td>46</td>\n",
+              "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
+              "      <td>8</td>\n",
+              "      <td>8</td>\n",
+              "      <td>abnormal</td>\n",
+              "      <td>Modifier</td>\n",
+              "      <td>absent</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>46</th>\n",
+              "      <td>46</td>\n",
+              "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
+              "      <td>14</td>\n",
+              "      <td>14</td>\n",
+              "      <td>right</td>\n",
+              "      <td>Direction</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>47</th>\n",
+              "      <td>46</td>\n",
+              "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
+              "      <td>15</td>\n",
+              "      <td>16</td>\n",
+              "      <td>paratracheal region</td>\n",
+              "      <td>External_body_part_or_region</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>48</th>\n",
+              "      <td>46</td>\n",
+              "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
+              "      <td>20</td>\n",
+              "      <td>21</td>\n",
+              "      <td>precarinal region</td>\n",
+              "      <td>Internal_organ_or_component</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>49</th>\n",
+              "      <td>46</td>\n",
+              "      <td>The CT scan of the chest showed an abnormal so...</td>\n",
+              "      <td>23</td>\n",
+              "      <td>24</td>\n",
+              "      <td>subcarinal region</td>\n",
+              "      <td>Internal_organ_or_component</td>\n",
+              "      <td>present</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "    task_id  ... assertion_label\n",
+              "0        46  ...         present\n",
+              "1        46  ...         present\n",
+              "2        46  ...         present\n",
+              "3        46  ...         present\n",
+              "4        46  ...         present\n",
+              "5        46  ...         present\n",
+              "6        46  ...         present\n",
+              "7        46  ...         present\n",
+              "8        46  ...         present\n",
+              "9        46  ...         present\n",
+              "10       46  ...         present\n",
+              "11       46  ...         present\n",
+              "12       46  ...         present\n",
+              "13       46  ...         present\n",
+              "14       46  ...         present\n",
+              "15       46  ...         present\n",
+              "16       46  ...         present\n",
+              "17       46  ...         present\n",
+              "18       46  ...          absent\n",
+              "19       46  ...          absent\n",
+              "20       46  ...          absent\n",
+              "21       46  ...         present\n",
+              "22       46  ...         present\n",
+              "23       46  ...         present\n",
+              "24       46  ...         present\n",
+              "25       46  ...         present\n",
+              "26       46  ...         present\n",
+              "27       46  ...         present\n",
+              "28       46  ...         present\n",
+              "29       46  ...         present\n",
+              "30       46  ...         present\n",
+              "31       46  ...          absent\n",
+              "32       46  ...         present\n",
+              "33       46  ...         present\n",
+              "34       46  ...         present\n",
+              "35       46  ...         present\n",
+              "36       46  ...         present\n",
+              "37       46  ...         present\n",
+              "38       46  ...          absent\n",
+              "39       46  ...          absent\n",
+              "40       46  ...         present\n",
+              "41       46  ...          absent\n",
+              "42       46  ...          absent\n",
+              "43       46  ...          absent\n",
+              "44       46  ...         present\n",
+              "45       46  ...          absent\n",
+              "46       46  ...         present\n",
+              "47       46  ...         present\n",
+              "48       46  ...         present\n",
+              "49       46  ...         present\n",
+              "\n",
+              "[50 rows x 7 columns]"
+            ]
+          },
+          "execution_count": 56,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "from itertools import groupby\n",
+        "\n",
+        "def split_get_ind(str_):\n",
+        "    ret = []\n",
+        "    for k, g in groupby(enumerate(str_), lambda x: x[1] != ' '):\n",
+        "        if k:\n",
+        "            pos, first_item = next(g)\n",
+        "            res = first_item + ''.join([x for _, x in g])\n",
+        "            ret.append( (pos, pos+len(res)))\n",
+        "    return ret\n",
+        "\n",
+        "tkn_st = []\n",
+        "tkn_ed = []\n",
+        "for i, row in all_tasks_assertions.iterrows():\n",
+        "    ass_tkns = split_get_ind(row['sentence'])\n",
+        "    st = -1\n",
+        "    ed = -1\n",
+        "    for tkn_ind, tkn in enumerate(ass_tkns):\n",
+        "        if int(row['begin']) in range(*tkn):\n",
+        "            st = tkn_ind\n",
+        "        if int(row['end']) in range(*tkn):\n",
+        "            ed = tkn_ind\n",
+        "    if st < 0 or ed < 0:\n",
+        "        tkn_st.append(None)\n",
+        "        tkn_ed.append(None)\n",
+        "    else:\n",
+        "        tkn_st.append(st)\n",
+        "        tkn_ed.append(ed)\n",
+        "    \n",
+        "    #print (st, ed)\n",
+        "all_tasks_assertions['tkn_start'] = tkn_st\n",
+        "all_tasks_assertions['tkn_end'] = tkn_ed\n",
+        "print (all_tasks_assertions.shape)\n",
+        "all_tasks_assertions.dropna(inplace=True)\n",
+        "all_tasks_assertions.reset_index(inplace=True, drop=True)\n",
+        "print (all_tasks_assertions.shape)\n",
+        "all_tasks_assertions = all_tasks_assertions[['task_id', 'sentence', 'tkn_start', 'tkn_end', 'chunk', 'entity', 'assertion_label']]\n",
+        "all_tasks_assertions.head(50)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gV6VBTQMVH8P"
+      },
+      "source": [
+        "# 3. Simply Upload data to an Alab Project (without pre-annotations)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 87
+        },
+        "id": "yjXuypwHVH8P",
+        "outputId": "0c908709-1a90-44ea-f58e-eb77d07cd03b"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "https://annotationlab.johnsnowlabs.com/api/projects/dummy/import\n",
+            "200\n"
+          ]
+        },
+        {
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "'{\"code\":500,\"description\":\"The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.\",\"error\":\"Internal Server Error\"}\\n'"
+            ]
+          },
+          "execution_count": 31,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "def create_sample_data(text_list):\n",
+        "    sample_data_for_upload = []\n",
+        "    for index, text in enumerate(text_list):\n",
+        "        sample_data_for_upload.append({'title': index, 'text': text})\n",
+        "\n",
+        "    return sample_data_for_upload\n",
+        "\n",
+        "sample_data_for_upload = create_sample_data(sample_data['text'].values)\n",
+        "\n",
+        "project_name = 'demo_100'\n",
+        "url = \"https://annotationlab.johnsnowlabs.com/api/projects/{}/import\".format(project_name)\n",
+        "print (url)\n",
+        "\n",
+        "headers = {\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "        \"accept\": \"*/*\"\n",
+        "    }\n",
+        "\n",
+        "cookies = get_cookies(username, password)\n",
+        "\n",
+        "resp = requests.post(url, headers = headers, cookies = cookies, json = sample_data_for_upload)\n",
+        "\n",
+        "resp.status_code\n",
+        "resp.text"
+      ]
     }
-   ],
-   "source": [
-    "def create_sample_data(text_list):\n",
-    "    sample_data_for_upload = []\n",
-    "    for index, text in enumerate(text_list):\n",
-    "        sample_data_for_upload.append({'title': index, 'text': text})\n",
-    "\n",
-    "    return sample_data_for_upload\n",
-    "\n",
-    "sample_data_for_upload = create_sample_data(sample_data['text'].values)\n",
-    "\n",
-    "project_name = 'demo_100'\n",
-    "url = \"https://annotationlab.johnsnowlabs.com/api/projects/{}/import\".format(project_name)\n",
-    "print (url)\n",
-    "\n",
-    "headers = {\n",
-    "        \"Content-Type\": \"application/json\",\n",
-    "        \"accept\": \"*/*\"\n",
-    "    }\n",
-    "\n",
-    "cookies = get_cookies(username, password)\n",
-    "\n",
-    "resp = requests.post(url, headers = headers, cookies = cookies, json = sample_data_for_upload)\n",
-    "\n",
-    "resp.status_code\n",
-    "resp.text"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "alab_api.ipynb",
-   "provenance": []
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "alab_api.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Environment (conda_tensorflow_p36)",
+      "language": "python",
+      "name": "conda_tensorflow_p36"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.10"
+    }
   },
-  "kernelspec": {
-   "display_name": "Environment (conda_tensorflow_p36)",
-   "language": "python",
-   "name": "conda_tensorflow_p36"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
When creating a conll file from A-Lab json exports, the AnnotationToolJsonReader does not give enough flexibility to generate a conll file with custom tokenization. This updated notebook gives users the option to use a regex tokenizer when creating the conll file from the json A-Lab export.