### PR TITLE
Added notebook for new external loadSavedModel

### DIFF
--- a/jupyter/transformers/Import External SavedModel From Remote Storage.ipynb
+++ b/jupyter/transformers/Import External SavedModel From Remote Storage.ipynb
@@ -1,0 +1,418 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/Import%20External%20SavedModel%20From%20Remote%20Storage.ipynb)"
+      ],
+      "metadata": {
+        "id": "lshuevA3Qv-N",
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "d9be2182-2a6c-4971-b524-7d6900906d63"
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# This is only needed to setup PySpark and Spark NLP on Colab\n",
+        "!wget http://setup.johnsnowlabs.com/colab.sh -O - | bash"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "f1de6429-2d6e-47e6-85ba-3a76e0b3958f"
+        },
+        "id": "Nt0jHURxzPTY"
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Import External SavedModel From Remote Storage\n",
+        "\n",
+        "This feature is available for `Spark NLP 4.2.2` and above. So please make sure you have upgraded to the latest Spark NLP release!\n",
+        "\n",
+        "This feature allows you to load external models (for example exported models from the transfomers library) from various remote locations. These include dbfs, hdfs and s3.\n",
+        "\n",
+        "For this example we will load an ALBERT model from the transformers library. On how to prepare the model and to export it properly, see the tutorials for the respective transformer at the [following discussion](https://github.com/JohnSnowLabs/spark-nlp/discussions/5669)!"
+      ],
+      "metadata": {
+        "id": "Zva6MvJyLeWi",
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "c9ac9309-e601-4215-8db2-fc5305c34705"
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Loading Models from the Databricks File System (DBFS)\n",
+        "First, make sure you have Spark NLP installed on your cluster.\n",
+        "\n",
+        "You can load models from a directory on DBFS by providing a path with the `dbfs:/` protocol."
+      ],
+      "metadata": {
+        "id": "MzxB-Nq6cxOA",
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "87ff4cde-67b8-4704-90a7-15718d8314a7"
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import sparknlp\n",
+        "from sparknlp.annotator import *\n",
+        "\n",
+        "spark = sparknlp.start()\n",
+        "\n",
+        "albert = AlbertEmbeddings.loadSavedModel(\n",
+        "     'dbfs:/FileStore/tables/johnsnow/albert-base-v2/',\n",
+        "     spark\n",
+        " )\\\n",
+        "    .setInputCols([\"sentence\",'token'])\\\n",
+        "    .setOutputCol(\"embeddings\")\\\n",
+        "    .setCaseSensitive(False)\\\n",
+        "    .setDimension(768)\\\n",
+        "    .setStorageRef('albert_base_uncased') \n"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "6cfc21e6-0bbc-4877-b3e7-66273238d9ae"
+        },
+        "id": "66MYkxENzPTb"
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If the file is on local file storage, it is asvisable to append the `file:/` protocol so that the correct path is resolved."
+      ],
+      "metadata": {
+        "id": "X2227WQ70npi"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import sparknlp\n",
+        "from sparknlp.annotator import *\n",
+        "\n",
+        "spark = sparknlp.start()\n",
+        "\n",
+        "albert = AlbertEmbeddings.loadSavedModel(\n",
+        "     'file:/databricks/driver/johnsnow/albert-base-v2/',\n",
+        "     spark\n",
+        " )\\\n",
+        "    .setInputCols([\"sentence\",'token'])\\\n",
+        "    .setOutputCol(\"embeddings\")\\\n",
+        "    .setCaseSensitive(False)\\\n",
+        "    .setDimension(768)\\\n",
+        "    .setStorageRef('albert_base_uncased') \n"
+      ],
+      "metadata": {
+        "id": "dBMhszZi0xZl"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Loading Models from the Hadoop File System (HDFS)\n",
+        "You can load models from a directory on HDFS by providing a path with the `hdfs:/` protocol. \n",
+        "\n",
+        "Here, the hdfs endpoint is reachable under `localhost:9000`."
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "c2666104-9516-4e84-81a1-66416a969120"
+        },
+        "id": "5hQWu39NzPTb"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import sparknlp\n",
+        "from sparknlp.annotator import *\n",
+        "\n",
+        "spark = sparknlp.start()\n",
+        "\n",
+        "albert = AlbertEmbeddings.loadSavedModel(\n",
+        "     'hdfs://localhost:9000/johnsnow/albert-base-v2/',\n",
+        "     spark\n",
+        " )\\\n",
+        "    .setInputCols([\"sentence\",'token'])\\\n",
+        "    .setOutputCol(\"embeddings\")\\\n",
+        "    .setCaseSensitive(False)\\\n",
+        "    .setDimension(768)\\\n",
+        "    .setStorageRef('albert_base_uncased') \n"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "5dfdc55c-d2fc-422b-b549-38b78aa21b09"
+        },
+        "id": "rPpd3fyEzPTc"
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Loading Models from S3\n",
+        "You can load models from a directory on S3 by providing a path with the `s3:/` protocol. \n",
+        "\n",
+        "You will need to create a custom Spark session with the proper credentials and permissions to access a directory on the s3 bucket. To see an example on how to set up access with temporary credentials see [Load Model From S3 from the SparkNLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/prediction/english/Load_Model_From_S3.ipynb).\n",
+        "\n",
+        "In this example, the bucket that will be used is called `johnsnow` and its region is `us-east-1`."
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "5bbc6544-aacb-4a52-86b1-37d3794ff118"
+        },
+        "id": "mdpBKnGTzPTc"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Anonymous Access\n",
+        "If the bucket is publicly accesible, then a Spark session with s3 support can be created like this to load the model from the bucket:"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "f13861fc-649c-4883-9c79-28c3e4016a50"
+        },
+        "id": "qPcL_PguzPTd"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pyspark.sql import SparkSession\n",
+        "from sparknlp.annotator import *\n",
+        "\n",
+        "spark = SparkSession.builder \\\n",
+        "    .master('local[*]') \\\n",
+        "    .appName('Spark NLP') \\\n",
+        "    .config(\"spark.driver.memory\", \"8g\") \\\n",
+        "    .config(\"spark.driver.maxResultSize\", \"2G\") \\\n",
+        "    .config(\"spark.serializer\", \"org.apache.spark.serializer.KryoSerializer\") \\\n",
+        "    .config(\"spark.kryoserializer.buffer.max\", \"200M\") \\\n",
+        "    .config(\"spark.jsl.settings.aws.region\", \"us-east-1\") \\\n",
+        "    .config(\"spark.jars.packages\", \"com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.2\") \\\n",
+        "    .getOrCreate()\n",
+        "\n",
+        "\n",
+        "albert = AlbertEmbeddings.loadSavedModel(\n",
+        "     's3://johnsnow/models/albert-base-v2/',\n",
+        "     spark\n",
+        " )\\\n",
+        "    .setInputCols([\"sentence\",'token'])\\\n",
+        "    .setOutputCol(\"embeddings\")\\\n",
+        "    .setCaseSensitive(False)\\\n",
+        "    .setDimension(768)\\\n",
+        "    .setStorageRef('albert_base_uncased') \n"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "c3612e0c-5fea-4565-a255-30a0cb6e87b7"
+        },
+        "id": "xAuLqKq8zPTd"
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Restricted Access\n",
+        "If the bucket needs credentials, then a Spark session with s3 support can be created like this to load the model from the bucket (taken from the workshop example).\n",
+        "\n",
+        "Note that `MY_ACCESS_KEY`, `MY_SECRET_KEY`, `MY_SESSION_KEY` need to be set for this example to work."
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "0d44a995-a96e-45c9-a2fc-4d387c667e80"
+        },
+        "id": "gsap1D7uzPTe"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(\"Enter your AWS Access Key:\")\n",
+        "MY_ACCESS_KEY = input()"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "8dd30b65-3f31-4b1a-9c7d-daca88d9ee37"
+        },
+        "id": "qjjL_Ez0zPTe"
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(\"Enter your AWS Secret Key:\")\n",
+        "MY_SECRET_KEY = input()"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "05dce6bc-9820-488f-a735-27a786d48253"
+        },
+        "id": "tjojm4vczPTf"
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(\"Enter your AWS Session Key:\")\n",
+        "MY_SESSION_KEY = input()"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "1c707c44-b63b-442d-8869-4280a11ef94b"
+        },
+        "id": "8pjzIQ_tzPTf"
+      },
+      "outputs": [],
+      "execution_count": null
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pyspark.sql import SparkSession\n",
+        "from sparknlp.annotator import *\n",
+        "\n",
+        "\n",
+        "spark = SparkSession.builder \\\n",
+        "    .appName(\"SparkNLP\") \\\n",
+        "    .master(\"local[*]\") \\\n",
+        "    .config(\"spark.driver.memory\", \"8G\") \\\n",
+        "    .config(\"spark.serializer\", \"org.apache.spark.serializer.KryoSerializer\") \\\n",
+        "    .config(\"spark.kryoserializer.buffer.max\", \"2000M\") \\\n",
+        "    .config(\"spark.driver.maxResultSize\", \"2G\") \\\n",
+        "    .config(\"spark.hadoop.fs.s3a.access.key\", MY_ACCESS_KEY) \\\n",
+        "    .config(\"spark.hadoop.fs.s3a.secret.key\", MY_SECRET_KEY) \\\n",
+        "    .config(\"spark.hadoop.fs.s3a.session.token\", MY_SESSION_KEY) \\\n",
+        "    .config(\"spark.hadoop.fs.s3a.aws.credentials.provider\", \"org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider\") \\\n",
+        "    .config(\"spark.hadoop.fs.s3a.path.style.access\", \"true\") \\\n",
+        "    .config(\"spark.jsl.settings.aws.region\", \"us-east-1\") \\\n",
+        "    .getOrCreate()\n",
+        "\n",
+        "\n",
+        "albert = AlbertEmbeddings.loadSavedModel(\n",
+        "     's3://johnsnow/models/albert-base-v2/',\n",
+        "     spark\n",
+        " )\\\n",
+        "    .setInputCols([\"sentence\",'token'])\\\n",
+        "    .setOutputCol(\"embeddings\")\\\n",
+        "    .setCaseSensitive(False)\\\n",
+        "    .setDimension(768)\\\n",
+        "    .setStorageRef('albert_base_uncased') \n"
+      ],
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "title": "",
+          "showTitle": false,
+          "inputWidgets": {},
+          "nuid": "5c181b23-d184-47b0-ab21-0d5ca1ff68f7"
+        },
+        "id": "MHPagZILzPTf"
+      },
+      "outputs": [],
+      "execution_count": null
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "mimetype": "text/x-python",
+      "name": "python",
+      "pygments_lexer": "ipython3",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "version": "3.8.10",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "application/vnd.databricks.v1+notebook": {
+      "notebookName": "Import External SavedModel From Remote Storage",
+      "dashboards": [],
+      "notebookMetadata": {
+        "pythonIndentUnit": 2
+      },
+      "language": "python",
+      "widgets": {},
+      "notebookOrigID": 3917489032437656
+    },
+    "colab": {
+      "collapsed_sections": [],
+      "provenance": []
+    },
+    "nteract": {
+      "version": "0.28.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
This PR adds a notebook showcasing the new external loadSavedModel method for transformer annotators.

This feature will be available from Spark NLP version 4.2.2.
