### PR TITLE
FEATURE MYJSL-358: Pass existing env variable on sudo session

### DIFF
--- a/jupyter/jsl_installation_script_ubuntu.sh
+++ b/jupyter/jsl_installation_script_ubuntu.sh
@@ -129,12 +129,12 @@ then
     echo "Virtual environment created at $env_pth ..."
     echo "Installing libraries ..."
     
-    sudo apt-get update -qq > /dev/null || apt-get update -qq > /dev/null
-    sudo apt-get -y upgrade -qq > /dev/null || apt-get upgrade -qq > /dev/null
-    sudo apt-get install -y jq -qq > /dev/null || apt-get install jq -qq > /dev/null
-    sudo apt-get purge -y openjdk-11* -qq > /dev/null || apt-get purge -y openjdk-11* -qq > /dev/null
-    sudo apt-get install -y openjdk-8-jdk-headless -qq > /dev/null || apt-get install -y openjdk-8-jdk-headless -qq > /dev/null
-    sudo apt-get install -y build-essential python3-pip  -qq > /dev/null || apt-get install -y build-essential python3-pip -qq > /dev/null
+    sudo -E apt-get update -qq > /dev/null || apt-get update -qq > /dev/null
+    sudo -E apt-get -y upgrade -qq > /dev/null || apt-get upgrade -qq > /dev/null
+    sudo -E apt-get install -y jq -qq > /dev/null || apt-get install jq -qq > /dev/null
+    sudo -E apt-get purge -y openjdk-11* -qq > /dev/null || apt-get purge -y openjdk-11* -qq > /dev/null
+    sudo -E apt-get install -y openjdk-8-jdk-headless -qq > /dev/null || apt-get install -y openjdk-8-jdk-headless -qq > /dev/null
+    sudo -E apt-get install -y build-essential python3-pip  -qq > /dev/null || apt-get install -y build-essential python3-pip -qq > /dev/null
     
     pip3 install -q --upgrade pip
     pip install -q --upgrade environment_kernels


### PR DESCRIPTION
Jira Ticket [MYJSL-358](https://johnsnowlabs.atlassian.net/browse/MYJSL-358)

The issue was that `DEBIAN_FRONTEND=noninteractive` was not passed to the sudo session. Since ubuntu 22.x has needrestart package installed by default, it tried to open an interactive shell in the console that lets you select the services to restart. 