### PR TITLE
Fix image download filename issue

### DIFF
--- a/products/aws_azure/visual/6.Spark_OCR_training_Table_recognition.ipynb
+++ b/products/aws_azure/visual/6.Spark_OCR_training_Table_recognition.ipynb
@@ -63,7 +63,7 @@
    },
    "outputs": [],
    "source": [
-    "!gdown 1e2xnujGxcl0n0mTPNcV_YdlDx0V3NDMS"
+    "!gdown --output shareholders.jpg 1e2xnujGxcl0n0mTPNcV_YdlDx0V3NDMS"
    ]
   },
   {
@@ -118,7 +118,7 @@
     }
    ],
    "source": [
-    "imagePath = \"cTDaR_t10096.jpg\"\n",
+    "imagePath = \"shareholders.jpg\"\n",
     "\n",
     "df = spark.read.format(\"binaryFile\").load(imagePath)\n",
     "df.show()"
@@ -560,7 +560,7 @@
     }
    ],
    "source": [
-    "!gdown 1AhAKlyxX_PEWI9bI0M0KH0wgzrKOpLTt"
+    "!gdown --output budget.pdf 1AhAKlyxX_PEWI9bI0M0KH0wgzrKOpLTt"
    ]
   },
   {
@@ -725,7 +725,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the notebook [6.Spark_OCR_training_Table_recognition.ipynb](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/products/aws_azure/visual/6.Spark_OCR_training_Table_recognition.ipynb) when we are downloading the  .jpg file like 
 
![image](https://github.com/JohnSnowLabs/spark-nlp-workshop/assets/101416953/e0c0ed93-e81c-4c31-b896-032cf2773033)

In the saved path it is showing `/home/ubuntu/notebooks/examples/visual/uc?id=1e2xnujGxcl0n0mTPNcV_YdlDx0V3NDMS`
But the correct path should be  `/home/ubuntu/notebooks/examples/visual/cTDaR_t10096.jpg`, because of this it is giving error  
during loading the file.

So for this we can mention the name of the file while saving
 