### PR TITLE
Added new parameters and pipeline examples to the MOOC Deidentification notebook

### DIFF
--- a/Spark_NLP_Udemy_MOOC/Healthcare_NLP/DeIdentification.ipynb
+++ b/Spark_NLP_Udemy_MOOC/Healthcare_NLP/DeIdentification.ipynb
@@ -24,7 +24,7 @@
         "id": "AOn8d1tcBkK3"
       },
       "source": [
-        "# **Deidentification**"
+        "# **De-identification**"
       ]
     },
     {
@@ -33,7 +33,7 @@
         "id": "WimihSwD3vtH"
       },
       "source": [
-        "This notebook will cover the different parameters and usages of `Deidentification`. This annotator provides the ability to obfuscate or mask the entities that contains personal information.\n",
+        "This notebook covers the different parameters and usages of `Deidentification`. This annotator provides the ability to obfuscate or mask the entities that contain personal information.\n",
         "\n",
         "**📖 Learning Objectives:**\n",
         "\n",
@@ -41,7 +41,7 @@
         "\n",
         "2. Colab setup\n",
         "\n",
-        "3. Become comfortable with deidentiifcation using the different parameters of the annotator.\n",
+        "3. Become comfortable with `Deidentification` using the different parameters of the annotator.\n",
         "\n",
         "\n",
         "**🔗 Helpful Links:**\n",
@@ -70,29 +70,31 @@
         "id": "TjDKOoZ4Fc8G"
       },
       "source": [
-        "Deidentification is a critical and important technology to facilitate the use of structured or unstructured clinical text while protecting patient privacy and confidentiality. John Snow Labs teams has invested great efforts in developing methods and corpora for deidentification of clinical text, PDF, image, DICOM, containing Protected Health Information (PHI):\n",
+        "De-identification is a critical and important technology to facilitate the use of structured or unstructured clinical text while protecting patient privacy and confidentiality. John Snow Labs teams have invested great efforts in developing methods and corpora for de-identification of clinical text, PDF, image, and DICOM files containing Protected Health Information (PHI):\n",
         "\n",
-        "*   individual’s past, present, or future physical or mental health or condition.\n",
-        "*   provision of health care to the individual.\n",
-        "*   past, present, or future payment for the health care.\n",
+        "*   an individual’s past, present or future physical or mental health condition;\n",
+        "*   the provision of health care to the individual; and\n",
+        "*   the past, present, or future payments for health care.\n",
         "\n",
-        "Protected health information includes many common identifiers (e.g., name, address, birth date, Social Security Number) when they can be associated with the health information.\n",
+        "PHI includes many common identifiers, such as name, address, birth date, and Social Security Number, when these can be associated with health information.\n",
         "\n",
-        "Spark NLP for Healthcare proposes several techniques and strategies for deidentification, the principal ones are:\n",
+        "Spark NLP for Healthcare provides several techniques and strategies for de-identification, the principal ones include:\n",
         "\n",
         "\n",
         "*   **Mask**:\n",
         "\n",
-        "          *   entity_labels: Mask with the entity type of that chunk. (default)\n",
-        "          *   same_length_chars: Mask the deid entities with same length of asterix ( * ) with brackets ( [ , ] ) on both end.\n",
-        "          *   fixed_length_chars: Mask the deid entities with a fixed length of asterix ( * ). The length is setting up using the setFixedMaskLength() method.\n",
+        "          * entity_labels (default): masks each detected entity using its corresponding entity label (e.g., [NAME], [DATE], [LOCATION]).\n",
+        "          * same_length_chars: masks de-identified entities with the same number of asterisks (*) as the original token length, enclosed in brackets ([ ]).\n",
+        "          Example: John Doe → [******]\n",
+        "          * fixed_length_chars: Masks all de-identified entities with a fixed-length sequence of asterisks (*). The length can be configured using the setFixedMaskLength() method.\n",
+        "          Example (fixed length = 5): John Doe → [*****]\n",
         "\n",
         "\n",
-        "*   **Obfuscation**: replace sensitive entities with random values of the same type.\n",
+        "*   **Obfuscation**: replaces sensitive entities with random but realistic values of the same type. For example, a detected name might be replaced with another randomly generated name, or a date with another plausible date within a similar range. This approach preserves linguistic structure while protecting PHI.\n",
         "\n",
-        "*   **Faker**:  allows the user to use a set of fake entities that are in the memory of spark-nlp-internal\n",
+        "*   **Faker**: uses a predefined set of synthetic (fake) entities stored in the internal Spark NLP memory (spark-nlp-internal).\n",
         "\n",
-        "Also there is an advanced option allowing to deidentify with multiple modes at the same time. (Multi-Mode Deididentification)."
+        "* **Multi-Mode De-identification**: Spark NLP for Healthcare also supports an advanced multi-mode configuration, enabling multiple de-identification strategies to be applied simultaneously."
       ]
     },
     {
@@ -110,7 +112,7 @@
         "id": "Bl0hQS-nR_T5"
       },
       "source": [
-        "This module is licensed, so you need a valid license json file.\n",
+        "This module is licensed, so you need a valid license JSON file.\n",
         "\n"
       ]
     },
@@ -157,7 +159,7 @@
       "source": [
         "from johnsnowlabs import nlp, medical\n",
         "\n",
-        "# After uploading your license run this to install all licensed Python Wheels and pre-download Jars the Spark Session JVM\n",
+        "# After uploading your license run this to install all licensed Python Wheels and pre-download Jars to the Spark Session JVM\n",
         "nlp.install()"
       ]
     },
@@ -172,26 +174,40 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
+      "metadata": {
+        "id": "RzoB0Q0WNWj1"
+      },
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "import pyspark.sql.functions as F\n",
+        "\n",
+        "# Automatically load license data and start a session with all jars user has access to\n",
+        "spark = nlp.start()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "spark"
+      ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 254
+          "height": 219
         },
-        "id": "RzoB0Q0WNWj1",
-        "outputId": "b4de528b-1f74-4563-dd17-3130f8dddb5b"
+        "id": "qnFK1tpD26Kg",
+        "outputId": "ab58d53e-8d8d-4dea-c32b-a345fc194678"
       },
+      "execution_count": 5,
       "outputs": [
         {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "👌 Detected license file /content/spark_nlp_for_healthcare_spark_ocr_10494.json\n",
-            "👌 Launched \u001b[92mcpu optimized\u001b[39m session with with: 🚀Spark-NLP==6.1.3, 💊Spark-Healthcare==6.1.1, running on ⚡ PySpark==3.4.0\n"
-          ]
-        },
-        {
+          "output_type": "execute_result",
           "data": {
+            "text/plain": [
+              "<pyspark.sql.session.SparkSession at 0x7cbc152e7110>"
+            ],
             "text/html": [
               "\n",
               "            <div>\n",
@@ -200,7 +216,7 @@
               "        <div>\n",
               "            <p><b>SparkContext</b></p>\n",
               "\n",
-              "            <p><a href=\"http://16747dd3c457:4040\">Spark UI</a></p>\n",
+              "            <p><a href=\"http://4af961103114:4040\">Spark UI</a></p>\n",
               "\n",
               "            <dl>\n",
               "              <dt>Version</dt>\n",
@@ -214,23 +230,11 @@
               "        \n",
               "            </div>\n",
               "        "
-            ],
-            "text/plain": [
-              "<pyspark.sql.session.SparkSession at 0x7acd4a11fbc0>"
             ]
           },
-          "execution_count": 4,
           "metadata": {},
-          "output_type": "execute_result"
+          "execution_count": 5
         }
-      ],
-      "source": [
-        "import pandas as pd\n",
-        "import pyspark.sql.functions as F\n",
-        "\n",
-        "# Automatically load license data and start a session with all jars user has access to\n",
-        "spark = nlp.start()\n",
-        "spark"
       ]
     },
     {
@@ -241,6 +245,13 @@
       "source": [
         "## **🖨️ Input/Output Annotation Types**"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [],
+      "metadata": {
+        "id": "6pWrGh9XQ-Kp"
+      }
     },
     {
       "cell_type": "markdown",
@@ -364,7 +375,7 @@
         "\n",
         "- `entityCasingModes`: (Param[String]) Dictionary path where is the json that contains the entity casing modes.\n",
         "\n",
-        "- `GenderAwareness`: (BooleanParam) Set whether to use gender-aware names or not during obfuscation.\n",
+        "- `GenderAwareness`: (BooleanParam) Set whether to use gender-aware names or not during obfuscation. This param effects only names. If value is true, it might decrease performance. Default: False\n",
         "\n",
         "- `AgeRangesByHipaa`: (BooleanParam) Set whether to obfuscate ages based on HIPAA (Health Insurance Portability and Accountability Act) Privacy Rule.\n",
         "\n",
@@ -381,7 +392,43 @@
         "\n",
         "- `KeepYear`: (BooleanParam) Sets whether to keep the year intact when obfuscating date entities. If True, the year will remain unchanged during the obfuscation process. If False, the year will be modified along with the month and day.\n",
         "\n",
-        "\n"
+        "- `AdditionalDateFormats`: (formats: list) Sets additional date formats to be considered during date obfuscation. This allows users to specify custom date formats in addition to the default date formats.\n",
+        "\n",
+        "- `BlackListEntities`: (value) Sets a list of entities coming from NER or regex rules that will be ignored for masking or obfuscation. The rest entities will be processed. Default: []\n",
+        "\n",
+        "- `ConsistentAcrossNameParts`: (BooleanParam) Sets whether to enforce consistent obfuscation across name parts, even when they appear separately. When set to True, the same transformation or obfuscation will be applied consistently to all parts of the same name entity, even if those parts appear separately.\n",
+        "\n",
+        "- `CountryObfuscation`: (BooleanParam) Sets whether to obfuscate country entities or not. If True, country entities will be obfuscated. If False, country entities will not be obfuscated.\n",
+        "\n",
+        "- `DateEntities`: (entities: list) Sets list of date entities. Default: [‘DATE’, ‘DOB’, ‘DOD’, ‘EFFDATE’, ‘FISCAL_YEAR’]\n",
+        "\n",
+        "- `GeoConsistency`: (BooleanParam) Sets whether to enforce consistent obfuscation across geographical entities: state, city, street, zip and phone.\n",
+        "\n",
+        "- `groupByCol` : The column name used to group the dataset. This parameter is used in conjunction with consistentObfuscation to ensure consistent obfuscation within each group. When groupByCol is set, the dataset is partitioned into groups based on the values of the specified column. Default: \"\" (empty string, meaning no grouping)\n",
+        "\n",
+        "- `KeepMonth`: (BooleanParam) Sets whether to keep the month intact when obfuscating date entities. If True, the month will remain unchanged during the obfuscation process. If False, the month will be modified along with the year and day. Default: False.\n",
+        "\n",
+        "- `KeepTextSizeForObfuscation``: (BooleanParam) It specifies whether the output should maintain the same character length as the input text. If True, the output text will remain the same if same length is available, else length might vary. If False, the output will be completely random. Default: False\n",
+        "\n",
+        "- `MaxRandomDisplacementDays`: (days: int) Sets maximum number of days for random date displacement. Default is 1825.\n",
+        "\n",
+        "- `ObfuscateZipByHipaa`: (BooleanParam) Sets whether to apply HIPAA Safe Harbor ZIP code obfuscation rules.\n",
+        "\n",
+        "- `obfuscationEquivalents` : (equivalents) used to define variant-to-canonical mappings to ensure consistent obfuscation.\n",
+        "Each pair should contain three elements: variant, entity type, and canonical.\n",
+        "The pairs must have exactly 3 elements: [variant, entityType, canonical].\n",
+        "\n",
+        "- `ObfuscationEquivalentsResource`: (path, read_as=ReadAs.TEXT, options=None) Allows loading obfuscation equivalents from an external file (e.g., CSV). Supports custom delimiter through the options parameter.\n",
+        "\n",
+        "- `EnableDefaultObfuscationEquivalents`: (BooleanParam) Sets whether to enable default obfuscation equivalents for common entities. This parameter allows the system to automatically include a set of predefined common English name equivalents. Default is False.\n",
+        "\n",
+        "- `StaticObfuscationPairs`: (pairs: list) Sets the static obfuscation pairs This method is used to set static obfuscation pairs that will be used for de-identification. Each pair should contain three elements: original, entity type, and fake. The pairs must have exactly 3 elements: [original, entityType, fake].\n",
+        "\n",
+        "- `StaticObfuscationPairsResource`: (path, read_as=ReadAs.TEXT, options=None) Sets file with static obfuscation pairs The pairs must have exactly 3 elements: [original, entityType, fake]. The first element is the original value, the second is the entity type, and the third is the fake value. A delimiter is used to separate the elements in each line. You can specify the delimiter in the options parameter.\n",
+        "\n",
+        "- `SameEntityThreshold`: (s) Sets similarity threshold [0.0-1.0] to consider two appearances of an entity as the same (default: 0.9).\n",
+        "\n",
+        "- `UseShiftDays` (s): Sets if you want to use the random shift day when the document has this in its metadata. Default: False\n"
       ]
     },
     {
@@ -422,25 +469,19 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "C5IbTr6pO6LM",
-        "outputId": "51852083-1255-4a08-ed58-857b9e0e2214"
+        "outputId": "422c6340-abf0-45a8-c1c5-5f085dec1c79"
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
             "embeddings_clinical download started this may take some time.\n",
             "Approximate size to download 1.6 GB\n",
             "[OK!]\n",
             "ner_deid_generic_augmented download started this may take some time.\n",
             "Approximate size to download 13.8 MB\n",
-            "[OK!]\n",
-            "+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+\n",
-            "|                text|            document|            sentence|               token|          embeddings|                 ner|           ner_chunk|   deid_entity_label|                 aux|    deid_same_length|   deid_fixed_length|\n",
-            "+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+\n",
-            "|\\nRecord date : 2...|[{document, 0, 23...|[{document, 1, 45...|[{token, 1, 6, Re...|[{word_embeddings...|[{named_entity, 1...|[{chunk, 15, 24, ...|[{document, 0, 36...|[{chunk, 14, 17, ...|[{document, 0, 44...|[{document, 0, 32...|\n",
-            "+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+\n",
-            "\n"
+            "[OK!]\n"
           ]
         }
       ],
@@ -520,9 +561,50 @@
         "Record date : 2093-01-13 , David Hale , M.D . , Name : Hendrickson Ora , MR # 7194334 Date : 01/13/93 . PCP : Oliveira , 25 years-old , Record date : 2079-11-09 . Cocke County Baptist Hospital , 0295 Keats Street , Phone 55-555-5555 .\n",
         "'''\n",
         "\n",
-        "result = model_deid.transform(spark.createDataFrame([[text]]).toDF(\"text\"))\n",
-        "\n",
-        "result.show()"
+        "result = model_deid.transform(spark.createDataFrame([[text]]).toDF(\"text\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's see the results of the different types of masking policies."
+      ],
+      "metadata": {
+        "id": "x145ciDi6SXz"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "result.select(\n",
+        "    result.text.alias(\"text\"),\n",
+        "    result.ner_chunk.result.alias(\"ner_chunk\"),\n",
+        "    result.deid_entity_label.result.alias(\"deid_entity_label\"),\n",
+        "    result.deid_same_length.result.alias(\"deid_same_length\"),\n",
+        "    result.deid_fixed_length.result.alias(\"deid_fixed_length\")\n",
+        ").show(truncate=50)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "f3eKKwWI1l9o",
+        "outputId": "e968c2e2-77f6-4ea4-fcdf-deb0ebe238a2"
+      },
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+\n",
+            "|                                              text|                                         ner_chunk|                                 deid_entity_label|                                  deid_same_length|                                 deid_fixed_length|\n",
+            "+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+\n",
+            "|\\nRecord date : 2093-01-13 , David Hale , M.D ....|[2093-01-13, David Hale, Hendrickson Ora, 71943...|[Record date : <DATE> , <NAME> , M.D ., , Name ...|[Record date : [********] , [********] , M.D .,...|[Record date : **** , **** , M.D ., , Name : **...|\n",
+            "+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+--------------------------------------------------+\n",
+            "\n"
+          ]
+        }
       ]
     },
     {
@@ -538,7 +620,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -927,7 +1009,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1266,7 +1348,7 @@
       "source": [
         "We have multi-mode functionality in the `DeIdentification()`.\n",
         "\n",
-        "By providing a json file to the `setSelectiveObfuscationModes(\"a JSON path\")` parameter, we are able to use multi-mode in de-identification. <br/>\n",
+        "By providing a JSON file to the `setSelectiveObfuscationModes(\"a JSON path\")` parameter, we are able to use multi-mode in de-identification. <br/>\n",
         "\n",
         "\n",
         "\n",
@@ -1294,7 +1376,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -1632,6 +1714,1353 @@
     },
     {
       "cell_type": "markdown",
+      "source": [
+        "### setObfuscationEquivalents()"
+      ],
+      "metadata": {
+        "id": "CMZp_noGqx7a"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Sets variant-to-canonical entity mappings to ensure consistent obfuscation.\n",
+        "\n",
+        "This function allows you to define equivalence rules for entity variants that should be obfuscated the same way. For example, the names “Alex” and “Alexander” will always be mapped to the same obfuscated value if they are linked to the same canonical form.\n",
+        "\n",
+        "It accepts a list of string triplets, where each triplet defines:\n",
+        "variant: A non-standard, short, or alternative form of a value (e.g., “Alex”)\n",
+        "\n",
+        "entityType: The type of the entity (e.g., “NAME”, “STATE”, “COUNTRY”)\n",
+        "\n",
+        "canonical: The standardized form all variants map to (e.g., “Alexander”)"
+      ],
+      "metadata": {
+        "id": "KWBrpM5nvO9E"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "equivalents = [\n",
+        "    [\"Alex Brown\", \"NAME\", \"Alexander Brown\"],\n",
+        "    [\"Rob McMaster\", \"NAME\", \"Robert McMaster\"],\n",
+        "    [\"CA\", \"LOCATION\", \"California\"],\n",
+        "    [\"Calif\", \"LOCATION\", \"California\"]\n",
+        "]\n",
+        "obfuscation_equivalents = medical.DeIdentification()\\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"ner_chunk\"]) \\\n",
+        "    .setOutputCol(\"obfuscation_equivalents\") \\\n",
+        "    .setMode(\"obfuscate\")\\\n",
+        "    .setObfuscationEquivalents(equivalents)\\\n",
+        "    .setEnableDefaultObfuscationEquivalents(False)\n",
+        "\n",
+        "deidPipeline = nlp.Pipeline(stages=[\n",
+        "      documentAssembler,\n",
+        "      sentenceDetector,\n",
+        "      tokenizer,\n",
+        "      word_embeddings,\n",
+        "      clinical_ner,\n",
+        "      ner_converter,\n",
+        "      obfuscation_equivalents])"
+      ],
+      "metadata": {
+        "id": "Zc5CGvvDvlLp"
+      },
+      "execution_count": 124,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "empty_data = spark.createDataFrame([[\"\"]]).toDF(\"text\")\n",
+        "model_deid = deidPipeline.fit(empty_data)\n",
+        "#sample data\n",
+        "\n",
+        "text ='''\n",
+        "Record date: 01-10-2020. Alex Brown , M.D.\n",
+        "Name: Alexander Brown, MRN 7194334 Date: 01/14/95.\n",
+        "Blue Mountain Hospital 1095 Green Street, CA, USA. Phone 55-555-5555 .\n",
+        "Merry Mount Hospital 4596 Blue Street, Calif, USA. Phone 44-444-4444 .\n",
+        "'''\n",
+        "result = model_deid.transform(spark.createDataFrame([[text]]).toDF(\"text\"))\n"
+      ],
+      "metadata": {
+        "id": "s0Ih6BWsm9JW"
+      },
+      "execution_count": 125,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can see that Alexander Brown and Alex Brown where obfuscated with the same name, in this case, Celester Glow."
+      ],
+      "metadata": {
+        "id": "aWuyULUAoSDE"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pyspark.sql import functions as F\n",
+        "\n",
+        "result.select(\n",
+        "    F.explode(\n",
+        "        F.arrays_zip(\n",
+        "            result.sentence.result,\n",
+        "            result.obfuscation_equivalents.result\n",
+        "        )\n",
+        "    ).alias(\"cols\")\n",
+        ").select(\n",
+        "    F.expr(\"cols['0']\").alias(\"sentence\"),\n",
+        "    F.expr(\"cols['1']\").alias(\"obfuscated\")\n",
+        ").toPandas()\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 269
+        },
+        "id": "ZbCg-E1uvG1M",
+        "outputId": "ae8844a7-81be-48aa-a7b0-0cdedb5cac59"
+      },
+      "execution_count": 127,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "                                            sentence  \\\n",
+              "0                           Record date: 01-10-2020.   \n",
+              "1                                  Alex Brown , M.D.   \n",
+              "2  Name: Alexander Brown, MRN 7194334 Date: 01/14...   \n",
+              "3  Blue Mountain Hospital 1095 Green Street, CA, ...   \n",
+              "4                                Phone 55-555-5555 .   \n",
+              "5  Merry Mount Hospital 4596 Blue Street, Calif, ...   \n",
+              "6                                Phone 44-444-4444 .   \n",
+              "\n",
+              "                                          obfuscated  \n",
+              "0                               Record date: <DATE>.  \n",
+              "1                               Celester Glow , M.D.  \n",
+              "2     Name: Celester Glow, MRN 2805665 Date: <DATE>.  \n",
+              "3  503 West Pine Street Alexandratown, 800 Kirnwo...  \n",
+              "4                                Phone 44-444-4444 .  \n",
+              "5  1401 River Road 309 N 14th St, 16001 W NINE MI...  \n",
+              "6                                Phone 55-555-5555 .  "
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-4ae0e5d4-29e2-4794-a783-b37fbd620f8b\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>sentence</th>\n",
+              "      <th>obfuscated</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Record date: 01-10-2020.</td>\n",
+              "      <td>Record date: &lt;DATE&gt;.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Alex Brown , M.D.</td>\n",
+              "      <td>Celester Glow , M.D.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Name: Alexander Brown, MRN 7194334 Date: 01/14...</td>\n",
+              "      <td>Name: Celester Glow, MRN 2805665 Date: &lt;DATE&gt;.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Blue Mountain Hospital 1095 Green Street, CA, ...</td>\n",
+              "      <td>503 West Pine Street Alexandratown, 800 Kirnwo...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Phone 55-555-5555 .</td>\n",
+              "      <td>Phone 44-444-4444 .</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>Merry Mount Hospital 4596 Blue Street, Calif, ...</td>\n",
+              "      <td>1401 River Road 309 N 14th St, 16001 W NINE MI...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>Phone 44-444-4444 .</td>\n",
+              "      <td>Phone 55-555-5555 .</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-4ae0e5d4-29e2-4794-a783-b37fbd620f8b')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-4ae0e5d4-29e2-4794-a783-b37fbd620f8b button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-4ae0e5d4-29e2-4794-a783-b37fbd620f8b');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "    <div id=\"df-cbddb334-e510-4b39-81b6-7792f0305566\">\n",
+              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-cbddb334-e510-4b39-81b6-7792f0305566')\"\n",
+              "                title=\"Suggest charts\"\n",
+              "                style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "      </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "      <script>\n",
+              "        async function quickchart(key) {\n",
+              "          const quickchartButtonEl =\n",
+              "            document.querySelector('#' + key + ' button');\n",
+              "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "          try {\n",
+              "            const charts = await google.colab.kernel.invokeFunction(\n",
+              "                'suggestCharts', [key], {});\n",
+              "          } catch (error) {\n",
+              "            console.error('Error during call to suggestCharts:', error);\n",
+              "          }\n",
+              "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "        }\n",
+              "        (() => {\n",
+              "          let quickchartButtonEl =\n",
+              "            document.querySelector('#df-cbddb334-e510-4b39-81b6-7792f0305566 button');\n",
+              "          quickchartButtonEl.style.display =\n",
+              "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "        })();\n",
+              "      </script>\n",
+              "    </div>\n",
+              "\n",
+              "    </div>\n",
+              "  </div>\n"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "dataframe",
+              "summary": "{\n  \"name\": \")\",\n  \"rows\": 7,\n  \"fields\": [\n    {\n      \"column\": \"sentence\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 7,\n        \"samples\": [\n          \"Record date: 01-10-2020.\",\n          \"Alex Brown , M.D.\",\n          \"Merry Mount Hospital 4596 Blue Street, Calif, USA.\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"obfuscated\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 7,\n        \"samples\": [\n          \"Record date: <DATE>.\",\n          \"Celester Glow , M.D.\",\n          \"1401 River Road 309 N 14th St, 16001 W NINE MILE RD.\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
+            }
+          },
+          "metadata": {},
+          "execution_count": 127
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### StaticObfuscationPairs()"
+      ],
+      "metadata": {
+        "id": "JY_C9rWysND9"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Sets the static obfuscation pairs This method is used to set static obfuscation pairs that will be used for de-identification. Each pair should contain three elements: original, entity type, and fake. The pairs must have exactly 3 elements: [original, entityType, fake]."
+      ],
+      "metadata": {
+        "id": "H2K8Ego2sPtJ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Static pairs for direct replacement: [original, entity_type, fake_value]\n",
+        "static_pairs = [\n",
+        "    [\"Alex Brown\", \"NAME\", \"Alexander Brown\"],\n",
+        "    [\"Rob McMaster\", \"NAME\", \"Robert McMaster\"],\n",
+        "    [\"CA\", \"LOCATION\", \"California\"]\n",
+        "]\n",
+        "\n",
+        "obfuscation_equivalents = medical.DeIdentification()\\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"ner_chunk\"]) \\\n",
+        "    .setOutputCol(\"obfuscation_equivalents\") \\\n",
+        "    .setMode(\"obfuscate\")\\\n",
+        "    .setStaticObfuscationPairs(static_pairs)\n",
+        "\n",
+        "deidPipeline = nlp.Pipeline(stages=[\n",
+        "      documentAssembler,\n",
+        "      sentenceDetector,\n",
+        "      tokenizer,\n",
+        "      word_embeddings,\n",
+        "      clinical_ner,\n",
+        "      ner_converter,\n",
+        "      obfuscation_equivalents])"
+      ],
+      "metadata": {
+        "id": "KbKV9hDsjpi8"
+      },
+      "execution_count": 82,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "empty_data = spark.createDataFrame([[\"\"]]).toDF(\"text\")\n",
+        "model_deid = deidPipeline.fit(empty_data)\n",
+        "#sample data\n",
+        "\n",
+        "text ='''\n",
+        "Record date: 01-10-2020. Alex Brown , M.D.\n",
+        "Name: Rob McMaster, MRN 7194334 Date: 01/14/95.\n",
+        "Record date: 2079-11-09. Blue Mountain Hospital 1095 Green Street, CA, USA. Phone 55-555-5555 .\n",
+        "'''\n",
+        "result = model_deid.transform(spark.createDataFrame([[text]]).toDF(\"text\"))\n"
+      ],
+      "metadata": {
+        "id": "QQQSEbN2I_V4"
+      },
+      "execution_count": 83,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can see that Alex Brown and Rob McMaster were replaced for Alexander Brown and Robert McMaster; and CA for California."
+      ],
+      "metadata": {
+        "id": "ZrBtK4QoseyQ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from pyspark.sql import functions as F\n",
+        "\n",
+        "result.select(\n",
+        "    F.explode(\n",
+        "        F.arrays_zip(\n",
+        "            result.sentence.result,\n",
+        "            result.obfuscation_equivalents.result\n",
+        "        )\n",
+        "    ).alias(\"cols\")\n",
+        ").select(\n",
+        "    F.expr(\"cols['0']\").alias(\"sentence\"),\n",
+        "    F.expr(\"cols['1']\").alias(\"obfuscated\")\n",
+        ").toPandas()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 238
+        },
+        "id": "AKg8LVLUwrwD",
+        "outputId": "60a20c7d-9dd0-4e26-e241-4086c0a30d0e"
+      },
+      "execution_count": 85,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "                                            sentence  \\\n",
+              "0                           Record date: 01-10-2020.   \n",
+              "1                                  Alex Brown , M.D.   \n",
+              "2    Name: Rob McMaster, MRN 7194334 Date: 01/14/95.   \n",
+              "3                           Record date: 2079-11-09.   \n",
+              "4  Blue Mountain Hospital 1095 Green Street, CA, ...   \n",
+              "5                                Phone 55-555-5555 .   \n",
+              "\n",
+              "                                          obfuscated  \n",
+              "0                               Record date: <DATE>.  \n",
+              "1                             Alexander Brown , M.D.  \n",
+              "2   Name: Robert McMaster, MRN 5972112 Date: <DATE>.  \n",
+              "3                               Record date: <DATE>.  \n",
+              "4  411 Fortuyn Rd 1500 N Ritter Ave, California, ...  \n",
+              "5                                Phone 33-333-3333 .  "
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-0d169724-94ca-4491-89ea-e0466925878c\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>sentence</th>\n",
+              "      <th>obfuscated</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Record date: 01-10-2020.</td>\n",
+              "      <td>Record date: &lt;DATE&gt;.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Alex Brown , M.D.</td>\n",
+              "      <td>Alexander Brown , M.D.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Name: Rob McMaster, MRN 7194334 Date: 01/14/95.</td>\n",
+              "      <td>Name: Robert McMaster, MRN 5972112 Date: &lt;DATE&gt;.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Record date: 2079-11-09.</td>\n",
+              "      <td>Record date: &lt;DATE&gt;.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Blue Mountain Hospital 1095 Green Street, CA, ...</td>\n",
+              "      <td>411 Fortuyn Rd 1500 N Ritter Ave, California, ...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>Phone 55-555-5555 .</td>\n",
+              "      <td>Phone 33-333-3333 .</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-0d169724-94ca-4491-89ea-e0466925878c')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-0d169724-94ca-4491-89ea-e0466925878c button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-0d169724-94ca-4491-89ea-e0466925878c');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "    <div id=\"df-0cdc5218-d9b1-42d7-bb8e-c4326ba753e8\">\n",
+              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-0cdc5218-d9b1-42d7-bb8e-c4326ba753e8')\"\n",
+              "                title=\"Suggest charts\"\n",
+              "                style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "      </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "      <script>\n",
+              "        async function quickchart(key) {\n",
+              "          const quickchartButtonEl =\n",
+              "            document.querySelector('#' + key + ' button');\n",
+              "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "          try {\n",
+              "            const charts = await google.colab.kernel.invokeFunction(\n",
+              "                'suggestCharts', [key], {});\n",
+              "          } catch (error) {\n",
+              "            console.error('Error during call to suggestCharts:', error);\n",
+              "          }\n",
+              "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "        }\n",
+              "        (() => {\n",
+              "          let quickchartButtonEl =\n",
+              "            document.querySelector('#df-0cdc5218-d9b1-42d7-bb8e-c4326ba753e8 button');\n",
+              "          quickchartButtonEl.style.display =\n",
+              "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "        })();\n",
+              "      </script>\n",
+              "    </div>\n",
+              "\n",
+              "    </div>\n",
+              "  </div>\n"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "dataframe",
+              "summary": "{\n  \"name\": \")\",\n  \"rows\": 6,\n  \"fields\": [\n    {\n      \"column\": \"sentence\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 6,\n        \"samples\": [\n          \"Record date: 01-10-2020.\",\n          \"Alex Brown , M.D.\",\n          \"Phone 55-555-5555 .\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"obfuscated\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 5,\n        \"samples\": [\n          \"Alexander Brown , M.D.\",\n          \"Phone 33-333-3333 .\",\n          \"Name: Robert McMaster, MRN 5972112 Date: <DATE>.\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
+            }
+          },
+          "metadata": {},
+          "execution_count": 85
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## setGeoConsistency()"
+      ],
+      "metadata": {
+        "id": "tbLdAJHOKony"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Sets whether to enforce consistent obfuscation across geographical entities: **state, city, street, zip and phone**.\n",
+        "\n",
+        "### Functionality Overview\n",
+        "This parameter enables intelligent geographical entity obfuscation that maintains realistic relationships between different geographic components. When enabled, the system ensures that obfuscated addresses form coherent, valid combinations rather than random replacements.\n",
+        "\n",
+        "### Supported Entity Types\n",
+        "The following geographical entities are processed with priority order:\n",
+        "- **state** (Priority: 0) - US state names\n",
+        "- **city** (Priority: 1) - City names\n",
+        "- **zip** (Priority: 2) - Zip codes\n",
+        "- **street** (Priority: 3) - Street addresses\n",
+        "- **phone** (Priority: 4) - Phone numbers\n",
+        "\n",
+        "### Language Requirement\n",
+        "**IMPORTANT:** Geographic consistency is only applied when:\n",
+        "- `geoConsistency` parameter is set to `True` **AND**\n",
+        "- `language` parameter is set to `\"en\"`\n",
+        "\n",
+        "For non-English configurations, this feature is automatically disabled regardless of the parameter setting."
+      ],
+      "metadata": {
+        "id": "s0YrN8hjKrHF"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We’ll use an NER model to extract the appropriate geographic entities."
+      ],
+      "metadata": {
+        "id": "jSq9lxAZe7cP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "labels = [\"AGE\", \"CITY\", \"COUNTRY\", \"DATE\", \"DOCTOR\", \"HOSPITAL\", \"IDNUM\", \"ORGANIZATION\",\n",
+        "          \"PATIENT\", \"PHONE\", \"PROFESSION\", \"STATE\", \"STREET\", \"ZIP\"]\n",
+        "\n",
+        "pretrained_zero_shot_ner = medical.PretrainedZeroShotNER().pretrained(\"zeroshot_ner_deid_subentity_docwise_large\", \"en\", \"clinical/models\")\\\n",
+        "    .setInputCols(\"sentence\", \"token\")\\\n",
+        "    .setOutputCol(\"ner\")\\\n",
+        "    .setPredictionThreshold(0.5)\\\n",
+        "    .setLabels(labels)\n",
+        "\n",
+        "ner_converter = medical.NerConverterInternal()\\\n",
+        "    .setInputCols(\"sentence\", \"token\", \"ner\")\\\n",
+        "    .setOutputCol(\"ner_chunk\")\n",
+        "\n",
+        "geo_consistency = medical.DeIdentification()\\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"ner_chunk\"]) \\\n",
+        "    .setOutputCol(\"geo_deidentified\") \\\n",
+        "    .setMode(\"obfuscate\")\\\n",
+        "    .setGeoConsistency(True)\\\n",
+        "    .setLanguage(\"en\")\\\n",
+        "\n",
+        "geo_deidPipeline = nlp.Pipeline(stages=[\n",
+        "      documentAssembler,\n",
+        "      sentenceDetector,\n",
+        "      tokenizer,\n",
+        "      word_embeddings,\n",
+        "      pretrained_zero_shot_ner,\n",
+        "      ner_converter,\n",
+        "      geo_consistency])\n",
+        "\n",
+        "empty_data = spark.createDataFrame([[\"\"]]).toDF(\"text\")\n",
+        "geo_model = geo_deidPipeline.fit(empty_data)\n",
+        "\n",
+        "# Sample data with geographic entities\n",
+        "geo_text = '''\n",
+        "Patient: John Smith, DOB: 05/15/1980\n",
+        "Address: 123 Main Street, Springfield, Illinois, 62701.\n",
+        "Phone: (217) 555-1234\n",
+        "Previous Address: 456 Oak Avenue, Chicago, Illinois, 60601.\n",
+        "Contact: (312) 555-5678\n",
+        "'''\n",
+        "\n",
+        "geo_result = geo_model.transform(spark.createDataFrame([[geo_text]]).toDF(\"text\"))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "GDFWInlzKu28",
+        "outputId": "939fd676-9777-411d-9ba0-ae2ce2c15f19"
+      },
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "zeroshot_ner_deid_subentity_docwise_large download started this may take some time.\n",
+            "Approximate size to download 1.5 GB\n",
+            "[OK!]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Notice how the geographic entities are obfuscated consistently:\n",
+        "- All addresses from the same state use cities from that state\n",
+        "- ZIP codes match the obfuscated cities\n",
+        "- Phone numbers use area codes consistent with the geographic locations"
+      ],
+      "metadata": {
+        "id": "VllTx1VxeMpj"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "geo_result.select(\n",
+        "    F.explode(F.arrays_zip(\n",
+        "        geo_result.sentence.result,\n",
+        "        geo_result.geo_deidentified.result\n",
+        "    )).alias(\"cols\")\n",
+        ").select(\n",
+        "    F.expr(\"cols['0']\").alias(\"original_sentence\"),\n",
+        "    F.expr(\"cols['1']\").alias(\"deidentified_sentence\")\n",
+        ").show(truncate=False)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "o3ZtHIcSKxOy",
+        "outputId": "af295432-539b-4a6c-c15a-1e6c8d794d6c"
+      },
+      "execution_count": 29,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+---------------------------------------------------------------------------------------------+----------------------------------------------------------------------------+\n",
+            "|original_sentence                                                                            |deidentified_sentence                                                       |\n",
+            "+---------------------------------------------------------------------------------------------+----------------------------------------------------------------------------+\n",
+            "|Patient: John Smith, DOB: 05/15/1980\\nAddress: 123 Main Street, Springfield, Illinois, 62701.|Patient: Fayrene Bors, DOB: <DATE>\\nAddress: 100 Main St, Nashua, NH, 03060.|\n",
+            "|Phone: (217) 555-1234\\nPrevious Address: 456 Oak Avenue, Chicago, Illinois, 60601.           |Phone: (603) 555-0181\\nPrevious Address: 100 Main St, Nashua, NH, 03060.    |\n",
+            "|Contact: (312) 555-5678                                                                      |Contact: (603) 555-0181                                                     |\n",
+            "+---------------------------------------------------------------------------------------------+----------------------------------------------------------------------------+\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### setAgeGroups()"
+      ],
+      "metadata": {
+        "id": "Q583s5W-j0Gu"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This method, setAgeGroups, is used in conjunction with the obfuscateByAgeGroups parameter to specify age ranges for obfuscation."
+      ],
+      "metadata": {
+        "id": "TZyg-l6hj6_6"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "deid_ner_enriched = MedicalNerModel.pretrained(\"ner_deid_subentity_augmented\", \"en\", \"clinical/models\") \\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"embeddings\"]) \\\n",
+        "    .setOutputCol(\"ner_subentity\")\n",
+        "\n",
+        "ner_converter_enriched = NerConverterInternal() \\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"ner_subentity\"]) \\\n",
+        "    .setOutputCol(\"ner_subentity_chunk\")\\\n",
+        "\n",
+        "obfuscation = DeIdentification()\\\n",
+        "    .setInputCols([\"sentence\", \"token\", \"ner_subentity_chunk\"]) \\\n",
+        "    .setOutputCol(\"deidentified\") \\\n",
+        "    .setMode(\"obfuscate\")\\\n",
+        "    .setObfuscateByAgeGroups(True)\\\n",
+        "    .setAgeGroups({\"baby\": [0, 1],\n",
+        "                   \"toddler\": [1, 4],\n",
+        "                   \"child\": [4, 13],\n",
+        "                   \"teenager\": [13, 20],\n",
+        "                   \"adult\": [20, 65],\n",
+        "                   \"senior\": [65, 100] })\n",
+        "\n",
+        "text ='''\n",
+        "Name: Joseph Brown, Age: 17, Phone: (9) 7765-5632.\n",
+        "This 17 yrs old male, presented with chest heaviness that started during a pick-up basketball game.\n",
+        "Mark Smith, aged 55, and his daughter (7) Mary were involved in an accident during their travel.\n",
+        "'''\n",
+        "\n",
+        "pipeline = Pipeline(\n",
+        "    stages=[\n",
+        "        documentAssembler,\n",
+        "        sentenceDetector,\n",
+        "        tokenizer,\n",
+        "        word_embeddings,\n",
+        "        deid_ner_enriched,\n",
+        "        ner_converter_enriched,\n",
+        "        obfuscation\n",
+        "])\n",
+        "\n",
+        "empty_data = spark.createDataFrame([[\"\"]]).toDF(\"text\")\n",
+        "\n",
+        "obfuscation_model = pipeline.fit(empty_data)\n",
+        "\n",
+        "\n",
+        "result = obfuscation_model.transform(spark.createDataFrame([[text]]).toDF(\"text\"))\n",
+        "\n",
+        "result.select(F.explode(F.arrays_zip(result.sentence.result,\n",
+        "                                     result.deidentified.result)).alias(\"cols\")) \\\n",
+        "      .select(F.expr(\"cols['0']\").alias(\"sentence\"), F.expr(\"cols['1']\").alias(\"deidentified\")).toPandas()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 233
+        },
+        "id": "F5uIYGXKKsbY",
+        "outputId": "d102c924-3df1-4ba3-f389-fbce89c95aa3"
+      },
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "ner_deid_subentity_augmented download started this may take some time.\n",
+            "Approximate size to download 14.1 MB\n",
+            "[OK!]\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "                                                                                              sentence                                                                                               deidentified\n",
+              "0                                                   Name: Joseph Brown, Age: 17, Phone: (9) 7765-5632.                                                 Name: Cleven Jasmine, Age: teenager, Phone: (6) 0074-4785.\n",
+              "1  This 17 yrs old male, presented with chest heaviness that started during a pick-up basketball game.  This teenager yrs old male, presented with chest heaviness that started during a pick-up basketball game.\n",
+              "2     Mark Smith, aged 55, and his daughter (7) Mary were involved in an accident during their travel.   Niki Jewell, aged adult, and his daughter (child) Mary were involved in an accident during their travel."
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-766a2fb9-cfc5-4a0c-98ea-e360a4865fc4\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>sentence</th>\n",
+              "      <th>deidentified</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Name: Joseph Brown, Age: 17, Phone: (9) 7765-5632.</td>\n",
+              "      <td>Name: Cleven Jasmine, Age: teenager, Phone: (6) 0074-4785.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>This 17 yrs old male, presented with chest heaviness that started during a pick-up basketball game.</td>\n",
+              "      <td>This teenager yrs old male, presented with chest heaviness that started during a pick-up basketball game.</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Mark Smith, aged 55, and his daughter (7) Mary were involved in an accident during their travel.</td>\n",
+              "      <td>Niki Jewell, aged adult, and his daughter (child) Mary were involved in an accident during their travel.</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-766a2fb9-cfc5-4a0c-98ea-e360a4865fc4')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-766a2fb9-cfc5-4a0c-98ea-e360a4865fc4 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-766a2fb9-cfc5-4a0c-98ea-e360a4865fc4');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "    <div id=\"df-03e64dd4-5696-414b-bb7b-167c1d3df0f6\">\n",
+              "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-03e64dd4-5696-414b-bb7b-167c1d3df0f6')\"\n",
+              "                title=\"Suggest charts\"\n",
+              "                style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "      </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "      <script>\n",
+              "        async function quickchart(key) {\n",
+              "          const quickchartButtonEl =\n",
+              "            document.querySelector('#' + key + ' button');\n",
+              "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "          try {\n",
+              "            const charts = await google.colab.kernel.invokeFunction(\n",
+              "                'suggestCharts', [key], {});\n",
+              "          } catch (error) {\n",
+              "            console.error('Error during call to suggestCharts:', error);\n",
+              "          }\n",
+              "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "        }\n",
+              "        (() => {\n",
+              "          let quickchartButtonEl =\n",
+              "            document.querySelector('#df-03e64dd4-5696-414b-bb7b-167c1d3df0f6 button');\n",
+              "          quickchartButtonEl.style.display =\n",
+              "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "        })();\n",
+              "      </script>\n",
+              "    </div>\n",
+              "\n",
+              "    </div>\n",
+              "  </div>\n"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "dataframe",
+              "summary": "{\n  \"name\": \"      \",\n  \"rows\": 3,\n  \"fields\": [\n    {\n      \"column\": \"sentence\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 3,\n        \"samples\": [\n          \"Name: Joseph Brown, Age: 17, Phone: (9) 7765-5632.\",\n          \"This 17 yrs old male, presented with chest heaviness that started during a pick-up basketball game.\",\n          \"Mark Smith, aged 55, and his daughter (7) Mary were involved in an accident during their travel.\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"deidentified\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 3,\n        \"samples\": [\n          \"Name: Cleven Jasmine, Age: teenager, Phone: (6) 0074-4785.\",\n          \"This teenager yrs old male, presented with chest heaviness that started during a pick-up basketball game.\",\n          \"Niki Jewell, aged adult, and his daughter (child) Mary were involved in an accident during their travel.\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}"
+            }
+          },
+          "metadata": {},
+          "execution_count": 58
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "z0JOqHjXs6IA"
       },
@@ -1650,7 +3079,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1737,12 +3166,12 @@
       "source": [
         "### `setDays()`\n",
         "\n",
-        "Using this param, we can set number of days to obfuscate by displacement the dates"
+        "Using this param, we can specify how many days to shift the dates in order to obfuscate them."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1813,7 +3242,9 @@
         "### `setUnnormalizedDateMode()`\n",
         "\n",
         "\n",
-        "This parameter is used to mask the DATE entities that can not be normalized. In the example below, please check `03Apr2022` which couldn't be normalized and it is masked in the output.\n",
+        "### Masking Unnormalized Date Formats\n",
+        "\n",
+        "`setUnnormalizedDateMode()` parameter is used to mask the DATE entities that can not be normalized. In the example below, please check `03Apr2022` which couldn't be normalized and it is masked in the output.\n",
         "\n",
         "- `setUnnormalizedDateMode(mask)` parameter is used to mask the DATE entities that can not be normalized.\n",
         "- `setUnnormalizedDateMode(obfuscate)` parameter is used to obfuscate the DATE entities that can not be normalized."
@@ -1821,27 +3252,27 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
+        "id": "ecMNdkr_V0Xq",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "lfb1CIPu0NI9",
-        "outputId": "04c122b1-ee76-40d7-e5f9-96e968227269"
+        "outputId": "a1c53ef7-8d74-4bce-d07a-b12547244ee4"
       },
       "outputs": [
         {
-          "name": "stdout",
           "output_type": "stream",
+          "name": "stdout",
           "text": [
-            "+----------------------------------------+---------+--------------------------------------------+-----------------------------------------------+\n",
-            "|text                                    |dateshift|result                                      |result                                         |\n",
-            "+----------------------------------------+---------+--------------------------------------------+-----------------------------------------------+\n",
-            "|Chris Brown was discharged on 10/02/2022|-5       |[Ivor Apley was discharged on 10/14/2022]   |[Addison Shim was discharged on 11/13/2022]    |\n",
-            "|Mark White was discharged on 02/28/2020 |-2       |[Mark White was discharged on 03/11/2020]   |[Mark White was discharged on 04/10/2020]      |\n",
-            "|John was discharged on 21/2021          |10       |[Kendell was discharged on 02/2021 ]        |[Alphonsa was discharged on 01/2021 ]          |\n",
-            "|John Moore was discharged on 12/31/2022 |20       |[Kendell Canny was discharged on 01/12/2023]|[Alphonsa Numbers was discharged on 02/11/2023]|\n",
-            "+----------------------------------------+---------+--------------------------------------------+-----------------------------------------------+\n",
+            "+----------------------------------------+---------+---------------------------------------------+----------------------------------------------+\n",
+            "|text                                    |dateshift|result                                       |result                                        |\n",
+            "+----------------------------------------+---------+---------------------------------------------+----------------------------------------------+\n",
+            "|Chris Brown was discharged on 10/02/2022|-5       |[Marshel Side was discharged on 09/27/2022]  |[Asenath Downs was discharged on 09/27/2022]  |\n",
+            "|Mark White was discharged on 02/28/2020 |-2       |[Ferrel Leghorn was discharged on 02/26/2020]|[Lorice Cho was discharged on 02/26/2020]     |\n",
+            "|John was discharged on 03 Apr2022       |10       |[Clydia was discharged on 13/Apr/2022]       |[Felizardo was discharged on 13/Apr/2022]     |\n",
+            "|John Moore was discharged on 12/31/2022 |20       |[Clydia Slough was discharged on 01/20/2023] |[Felizardo Makua was discharged on 01/20/2023]|\n",
+            "+----------------------------------------+---------+---------------------------------------------+----------------------------------------------+\n",
             "\n"
           ]
         }
@@ -1851,7 +3282,7 @@
         "    {'patientID' : ['A001', 'A001', 'A002', 'A002'],\n",
         "     'text' : ['Chris Brown was discharged on 10/02/2022',\n",
         "               'Mark White was discharged on 02/28/2020',\n",
-        "               'John was discharged on 21/2021 ',          # check this\n",
+        "               'John was discharged on 03 Apr2022',          # check this\n",
         "               'John Moore was discharged on 12/31/2022'\n",
         "              ],\n",
         "     'dateshift' : ['-5', '-2', '10', '20']\n",
@@ -1860,8 +3291,8 @@
         "\n",
         "my_input_df = spark.createDataFrame(data)\n",
         "\n",
-        "de_identification_mask = medical.DeIdentification() \\\n",
-        "    .setInputCols([\"ner_chunk\", \"token\", \"document\"]) \\\n",
+        "de_identification_mask = DeIdentification() \\\n",
+        "    .setInputCols([\"ner_chunk\", \"token\", \"document2\"]) \\\n",
         "    .setOutputCol(\"deid_text_mask\") \\\n",
         "    .setMode(\"obfuscate\") \\\n",
         "    .setObfuscateDate(True) \\\n",
@@ -1872,8 +3303,8 @@
         "    .setRegion('us')\\\n",
         "    .setUnnormalizedDateMode(\"mask\")\n",
         "\n",
-        "de_identification_obf = medical.DeIdentification() \\\n",
-        "    .setInputCols([\"ner_chunk\", \"token\", \"document\"]) \\\n",
+        "de_identification_obf = DeIdentification() \\\n",
+        "    .setInputCols([\"ner_chunk\", \"token\", \"document2\"]) \\\n",
         "    .setOutputCol(\"deid_text_obs\") \\\n",
         "    .setMode(\"obfuscate\") \\\n",
         "    .setObfuscateDate(True) \\\n",
@@ -1884,20 +3315,18 @@
         "    .setRegion('us')\\\n",
         "    .setUnnormalizedDateMode(\"obfuscation\")\n",
         "\n",
+        "pipeline = Pipeline().setStages([\n",
+        "    documentAssembler,\n",
+        "    documentHasher,\n",
+        "    tokenizer,\n",
+        "    embeddings,\n",
+        "    clinical_ner,\n",
+        "    ner_converter,\n",
+        "    de_identification_mask,\n",
+        "    de_identification_obf\n",
+        "])\n",
         "\n",
-        "\n",
-        "deidPipeline = nlp.Pipeline(stages=[\n",
-        "      documentAssembler,\n",
-        "      sentenceDetector,\n",
-        "      tokenizer,\n",
-        "      word_embeddings,\n",
-        "      clinical_ner,\n",
-        "      ner_converter,\n",
-        "      de_identification_mask,\n",
-        "      de_identification_obf])\n",
-        "\n",
-        "\n",
-        "output = deidPipeline.fit(my_input_df).transform(my_input_df)\n",
+        "output = pipeline.fit(my_input_df).transform(my_input_df)\n",
         "\n",
         "output.select('text', 'dateshift', 'deid_text_mask.result','deid_text_obs.result').show(truncate = False)"
       ]
@@ -1911,13 +3340,13 @@
         "### `setDateFormats()`\n",
         "\n",
         "\n",
-        "With this parameter, we can sets list of date formats to automatically displace if parsed.\n",
+        "With this parameter, we can set a list of date formats that should be automatically recognized and displaced if successfully parsed.\n",
         "In the example below, we will take two dates format: \"MM/dd/yy\" and \"yyyy-MM-dd\"."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -1966,14 +3395,18 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "1UDKVXwIXErN"
+      },
       "source": [
         " # Structured Deidentification for Relational Database"
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "BeHSXU_yXErR"
+      },
       "source": [
         "Let's install the MYSQL server dependencies"
       ]
@@ -1981,7 +3414,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "Aky9yrVKXErR",
+        "outputId": "c0050fce-3e6b-479c-96be-bdbc4abe502b"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -2015,7 +3451,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "8-uevp2ZXErR"
+      },
       "source": [
         "Now let's start the mysql service"
       ]
@@ -2023,7 +3461,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "s0xRgsEGXErS",
+        "outputId": "9ecdf68f-74ac-4a22-dfc1-9004a1eab656"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -2041,7 +3482,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "VPPnDAP-XErS"
+      },
       "source": [
         "Define the SQL commands to reset the root password\n"
       ]
@@ -2049,7 +3492,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "peY4LFaPXErS"
+      },
       "outputs": [],
       "source": [
         "reset_password_sql = \"\"\"\n",
@@ -2064,7 +3509,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "WVrMQ2tsXErS"
+      },
       "source": [
         "Let's restart the MySQL service to take effect"
       ]
@@ -2072,7 +3519,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "LQuslr_rXErS",
+        "outputId": "ad64c4ae-957b-4657-e87b-7b8bd7d4688d"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -2095,7 +3545,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "Wrkeb1pfXErS",
+        "outputId": "eab911b3-8e4b-43a5-993c-d30dcf048ba1"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -2116,7 +3569,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "-j2L57fVXErT"
+      },
       "source": [
         "Now, we will create a clinical database to be deidentified, called `healthcare_db` with two tables: patients and appointments with a relational join between them:\n"
       ]
@@ -2124,7 +3579,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "qX4EiZ6-XErT",
+        "outputId": "e2c1f0a0-18c4-418c-f8ec-4a135bf56a5b"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -2179,7 +3637,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "CH_NnhpQXErT"
+      },
       "source": [
         "Reading the relational database as spark df for further processing:"
       ]
@@ -2187,7 +3647,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "RVVTlTq3XErT",
+        "outputId": "debe3868-30d6-4389-a7ff-eb790a7b00a5"
+      },
       "outputs": [
         {
           "name": "stdout",
@@ -2220,7 +3683,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "RtelobTWXErT"
+      },
       "source": [
         "Now, let's import the database_deidentification utility module then setup the relational database deidentification options"
       ]
@@ -2228,7 +3693,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "7s4a9zvWXErU"
+      },
       "outputs": [],
       "source": [
         "from sparknlp_jsl.utils.database_deidentification import *"
@@ -2237,7 +3704,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "8hXlV7tZXErU"
+      },
       "outputs": [],
       "source": [
         "config = {\n",
@@ -2268,7 +3737,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "agHbNKOTXErU"
+      },
       "source": [
         "Performing the structured deidentification for the clinical relational database and showing the results"
       ]
@@ -2276,7 +3747,10 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "O0gOIfEmXErU",
+        "outputId": "5827ff85-345b-4bfc-b027-2670bbbfb427"
+      },
       "outputs": [
         {
           "name": "stdout",


### PR DESCRIPTION
Added the following parameters to the MOOC notebook list:
- setAdditionalDateFormats
- BlackListEntities
- ConsistentAcrossNameParts
- DateEntities
- setGeoConsistency
- groupByCol
- KeepMonth
- KeepTextSizeForObfuscation
- MaxRandomDisplacementDays
- ObfuscateZipByHipaa
- setSameEntityThreshold
- UseShifDays
- ObfuscationEquivalents

-Added pipeline examples for parameters setObfuscationEquivalents(), StaticObfuscationPairs(), setGeoConsistency(), setAgeGroups() in MOOC Deidentification.ipynb
- fixed example of setUnnormalizedDateMode()in MOOC notebook.
- fixed typos and style in several sections. 
- changed the results showing in Mask Mode section to better feature the different types of masking policies.    
