### PR TITLE
link attachment for Healtcare NLP notebook

### DIFF
--- a/tutorials/Certification_Trainings/Healthcare/1.7.Generative_AI_to_Ner_Training.ipynb
+++ b/tutorials/Certification_Trainings/Healthcare/1.7.Generative_AI_to_Ner_Training.ipynb
@@ -20,6 +20,13 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "If you are using the `johnsnowlabs` library, please use this  [01.8.Generative_AI_to_Ner_Training](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/01.8.Generative_AI_to_Ner_Training.ipynb) notebook."
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "okhT7AcXxben"
       },


### PR DESCRIPTION
I added link to [tutorials/Certification_Trainings/Healthcare/1.7.Generative_AI_to_Ner_Training](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/1.7.Generative_AI_to_Ner_Training.ipynb)  notebook for new created [healthcare-nlp/01.8.Generative_AI_to_Ner_Training.ipynb](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/healthcare-nlp/01.8.Generative_AI_to_Ner_Training.ipynb) notebook.